### PR TITLE
ci: gate deploy workflows with preflight checks

### DIFF
--- a/.github/workflows/cicd-deploy.yml
+++ b/.github/workflows/cicd-deploy.yml
@@ -15,22 +15,57 @@ permissions:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+    env:
+      DEPLOY_ENABLED: ${{ vars.ENABLE_OIDC_DEPLOY || 'false' }}
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID || '732190342674' }}
+      WIF_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER || secrets.GCP_WIF_PROVIDER }}
+      WIF_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL || secrets.GCP_WIF_SA_EMAIL }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
+      - name: Preflight deploy prerequisites
+        id: preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          if [ "${DEPLOY_ENABLED}" != "true" ]; then
+            missing+=("ENABLE_OIDC_DEPLOY variable is not true")
+          fi
+          if [ -z "${WIF_PROVIDER}" ]; then
+            missing+=("GCP_WORKLOAD_IDENTITY_PROVIDER/GCP_WIF_PROVIDER")
+          fi
+          if [ -z "${WIF_SERVICE_ACCOUNT}" ]; then
+            missing+=("GCP_SERVICE_ACCOUNT_EMAIL/GCP_WIF_SA_EMAIL")
+          fi
+          if [ -z "${GCP_PROJECT_ID}" ]; then
+            missing+=("GCP_PROJECT_ID")
+          fi
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            printf 'missing=%s\n' "${missing[*]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+            echo "missing=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Authenticate to Google Cloud
+        if: steps.preflight.outputs.ready == 'true'
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed
         with:
-          workload_identity_provider: projects/732190342674/locations/global/workloadIdentityPools/fractal5-github-pool/providers/github-provider
-          service_account: dominion-demo-oidc-sa@732190342674.iam.gserviceaccount.com
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
 
       - name: Set up gcloud
+        if: steps.preflight.outputs.ready == 'true'
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
         with:
-          project_id: 732190342674
+          project_id: ${{ env.GCP_PROJECT_ID }}
           version: ">= 363.0.0"
 
       - name: Submit Cloud Build
+        if: steps.preflight.outputs.ready == 'true'
         run: |
           REF="${GITHUB_REF##*/}"
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
@@ -40,6 +75,11 @@ jobs:
           fi
 
           gcloud builds submit \
-            --project=732190342674 \
+            --project=${GCP_PROJECT_ID} \
             --config cloudbuild.yaml \
             --substitutions=_TAG="${TAG}",_REGION=us-central1,_SERVICE_NAME=dominion-demo,_AR_REPO=dominion-demo-repo
+
+      - name: Skip summary
+        if: steps.preflight.outputs.ready != 'true'
+        run: |
+          echo "Skipping OIDC deploy. Missing prerequisites: ${{ steps.preflight.outputs.missing }}"

--- a/.github/workflows/production-deploy-optimized.yml
+++ b/.github/workflows/production-deploy-optimized.yml
@@ -77,15 +77,41 @@ jobs:
       GCP_REGION: us-central1
       SERVICE_NAME: dominion-os-demo
       IMAGE_REPO: us-central1-docker.pkg.dev/dominion-core-prod/dominion-os/dominion-os-demo
+      DEPLOY_ENABLED: ${{ vars.ENABLE_PROD_DEPLOY || 'false' }}
     
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
-      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v2
+      - name: Preflight deploy prerequisites
+        id: preflight
+        shell: bash
+        env:
+          GCP_ACCESS_TOKEN: ${{ secrets.GCP_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          missing=()
+          if [ "${DEPLOY_ENABLED}" != "true" ]; then
+            missing+=("ENABLE_PROD_DEPLOY variable is not true")
+          fi
+          if [ -z "${GCP_ACCESS_TOKEN}" ]; then
+            missing+=("GCP_ACCESS_TOKEN")
+          fi
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            printf 'missing=%s\n' "${missing[*]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+            echo "missing=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.preflight.outputs.ready == 'true'
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v2
 
       - name: Prepare Google Access Token
+        if: steps.preflight.outputs.ready == 'true'
         id: gcp-token
         env:
           GCP_ACCESS_TOKEN: ${{ secrets.GCP_ACCESS_TOKEN }}
@@ -100,9 +126,11 @@ jobs:
           echo "token_file=$TOKEN_FILE" >> "$GITHUB_OUTPUT"
       
       # Use Docker buildx for layer caching
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - if: steps.preflight.outputs.ready == 'true'
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       
       - name: Build with cache
+        if: steps.preflight.outputs.ready == 'true'
         env:
           CLOUDSDK_AUTH_ACCESS_TOKEN_FILE: ${{ steps.gcp-token.outputs.token_file }}
         run: |
@@ -117,6 +145,7 @@ jobs:
             .
       
       - name: Deploy to Cloud Run
+        if: steps.preflight.outputs.ready == 'true'
         env:
           CLOUDSDK_AUTH_ACCESS_TOKEN_FILE: ${{ steps.gcp-token.outputs.token_file }}
         run: |
@@ -131,6 +160,11 @@ jobs:
             --memory=512Mi \
             --timeout=60s \
             --concurrency=80
+
+      - name: Skip summary
+        if: steps.preflight.outputs.ready != 'true'
+        run: |
+          echo "Skipping cost-optimized deploy. Missing prerequisites: ${{ steps.preflight.outputs.missing }}"
       
       # No artifact upload unless failure
       - name: Upload failure logs

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -27,11 +27,36 @@ jobs:
       SERVICE_NAME: dominion-os-demo
       IMAGE_REPO: us-central1-docker.pkg.dev/dominion-core-prod/dominion-os/dominion-os-demo
       RELEASE_MANIFEST_PATH: release-manifest.json
+      DEPLOY_ENABLED: ${{ vars.ENABLE_PROD_DEPLOY || 'false' }}
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
+      - name: Preflight production deploy prerequisites
+        id: preflight
+        shell: bash
+        env:
+          GCP_ACCESS_TOKEN: ${{ secrets.GCP_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          missing=()
+          if [ "${DEPLOY_ENABLED}" != "true" ]; then
+            missing+=("ENABLE_PROD_DEPLOY variable is not true")
+          fi
+          if [ -z "${GCP_ACCESS_TOKEN}" ]; then
+            missing+=("GCP_ACCESS_TOKEN")
+          fi
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            printf 'missing=%s\n' "${missing[*]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+            echo "missing=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Capture Release Metadata
+        if: steps.preflight.outputs.ready == 'true'
         id: release
         shell: bash
         env:
@@ -120,11 +145,14 @@ jobs:
           PY
           echo "release_sha=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
 
-      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
+      - if: steps.preflight.outputs.ready == 'true'
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
 
-      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+      - if: steps.preflight.outputs.ready == 'true'
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 
       - name: Prepare Google Access Token
+        if: steps.preflight.outputs.ready == 'true'
         id: gcp-token
         env:
           GCP_ACCESS_TOKEN: ${{ secrets.GCP_ACCESS_TOKEN }}
@@ -139,16 +167,19 @@ jobs:
           echo "token_file=$TOKEN_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Configure Artifact Registry
+        if: steps.preflight.outputs.ready == 'true'
         run: |
           set -euo pipefail
           docker login -u oauth2accesstoken --password-stdin https://us-central1-docker.pkg.dev < "${{ steps.gcp-token.outputs.token_file }}"
 
       - name: Verify Public Demo Release Surface
+        if: steps.preflight.outputs.ready == 'true'
         run: |
           set -euo pipefail
           python scripts/verify_public_demo_surface.py
 
       - name: Build and Push Authoritative Demo Image
+        if: steps.preflight.outputs.ready == 'true'
         run: |
           set -euo pipefail
           docker buildx build \
@@ -159,6 +190,7 @@ jobs:
             .
 
       - name: Resolve Live Service URLs
+        if: steps.preflight.outputs.ready == 'true'
         id: urls
         env:
           CLOUDSDK_AUTH_ACCESS_TOKEN_FILE: ${{ steps.gcp-token.outputs.token_file }}
@@ -170,6 +202,7 @@ jobs:
           echo "widget_url=${WIDGET_URL}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy Authoritative Demo Service
+        if: steps.preflight.outputs.ready == 'true'
         env:
           CLOUDSDK_AUTH_ACCESS_TOKEN_FILE: ${{ steps.gcp-token.outputs.token_file }}
         run: |
@@ -186,6 +219,7 @@ jobs:
             --quiet
 
       - name: Verify Live Release Contract
+        if: steps.preflight.outputs.ready == 'true'
         env:
           CLOUDSDK_AUTH_ACCESS_TOKEN_FILE: ${{ steps.gcp-token.outputs.token_file }}
         run: |
@@ -202,3 +236,8 @@ jobs:
             --expected-source-repo "${{ steps.release.outputs.source_repo }}" \
             --expected-source-sha "${{ steps.release.outputs.source_sha }}" \
             --expected-source-version "${{ steps.release.outputs.source_version }}"
+
+      - name: Skip summary
+        if: steps.preflight.outputs.ready != 'true'
+        run: |
+          echo "Skipping production deploy. Missing prerequisites: ${{ steps.preflight.outputs.missing }}"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,27 +11,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
+      - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      with:
-        fetch-depth: 0
+        with:
+          fetch-depth: 0
 
-    - name: Run TruffleHog OSS
+      - name: Run TruffleHog OSS
         uses: trufflesecurity/trufflehog@afd5336caad0f61da51750ffe39869974b27b0db # main
-      with:
-        path: ./
-        base: main
-        head: HEAD
-        extra_args: --debug --only-verified
+        with:
+          path: ./
+          base: main
+          head: HEAD
+          extra_args: --debug --only-verified
 
-    - name: Run AI Token Detector
-      run: |
-        python scripts/ai_token_detector.py
+      - name: Run AI Token Detector
+        run: |
+          python scripts/ai_token_detector.py
 
-    - name: Upload security report
-      if: always()
-      continue-on-error: true
+      - name: Upload security report
+        if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: security-report
-        path: security_report.md
+        with:
+          name: security-report
+          path: security_report.md


### PR DESCRIPTION
## What\n- fix YAML indentation in security scan workflow\n- add preflight gating for OIDC and production deploy jobs\n- skip deploy jobs cleanly when required runtime secrets/vars are unavailable\n\n## Why\nStabilizes CI on protected main when cloud credentials are not configured or intentionally disabled.