### PR TITLE
fix(security): close oauth redirect finding on main

### DIFF
--- a/scripts/oauth_server/app.py
+++ b/scripts/oauth_server/app.py
@@ -97,8 +97,8 @@ if os.getenv("ENV", "development") == "production":
 @app.before_request
 def enforce_https():
     if not request.is_secure and os.getenv("ENV", "development") == "production":
-        relative_target = request.full_path if request.query_string else request.path
-        return redirect(relative_target, code=307)
+        logger.warning("Blocked insecure request path=%s", sanitize_log_value(request.path))
+        return jsonify({"error": "https_required"}), 403
 
 
 # Add logging to authentication events


### PR DESCRIPTION
Follow-up remediation after #105 to close remaining CodeQL url-redirection alert on main.\n\nChanges:\n- replace production insecure-request redirect with explicit 403 response in OAuth server pre-request hook\n\nValidation:\n- python -m py_compile scripts/oauth_server/app.py