### PR TITLE
Publish Dominion OS demo asset manifest

### DIFF
--- a/demo/assets/demo-manifest.json
+++ b/demo/assets/demo-manifest.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "schema": "f5.dominion.demo.assets.v1",
   "generatedAt": "2026-06-07T00:00:00Z",
   "sourceOfTruth": {
@@ -20,10 +20,6 @@
   },
   "assets": {
     "manifest": "https://demo-reduwyf2ra-uc.a.run.app/demo/assets/demo-manifest.json",
-    "config": "https://demo-reduwyf2ra-uc.a.run.app/demo/demo-config.js?v=20260326b",
-    "stylesheet": "https://demo-reduwyf2ra-uc.a.run.app/demo/assets/demo.css?v=20260326b",
-    "script": "https://demo-reduwyf2ra-uc.a.run.app/demo/assets/demo.js?v=20260326b",
-    "favicon": "https://demo-reduwyf2ra-uc.a.run.app/demo/assets/favicon.svg?v=20260326b",
     "videoMp4": null,
     "videoPoster": null,
     "demoDownload": null,
@@ -31,6 +27,9 @@
     "releaseReceiptsJson": null
   },
   "assetPolicy": {
+    "servedAssetRoutes": [
+      "/demo/assets/demo-manifest.json"
+    ],
     "directBinaryAssetsRequiredForFinalInlineEmbed": [
       "videoMp4",
       "demoDownload",

--- a/demo/assets/demo-manifest.json
+++ b/demo/assets/demo-manifest.json
@@ -1,0 +1,60 @@
+﻿{
+  "schema": "f5.dominion.demo.assets.v1",
+  "generatedAt": "2026-06-07T00:00:00Z",
+  "sourceOfTruth": {
+    "repository": "Fractal5-Solutions/dominion-os-demo-build",
+    "path": "demo/assets/demo-manifest.json",
+    "environment": "demo-sandbox",
+    "runtime": "cloud-run"
+  },
+  "runtime": {
+    "root": "https://demo-reduwyf2ra-uc.a.run.app/",
+    "demo": "https://demo-reduwyf2ra-uc.a.run.app/demo",
+    "health": "https://demo-reduwyf2ra-uc.a.run.app/health",
+    "status": "https://demo-reduwyf2ra-uc.a.run.app/status"
+  },
+  "sections": {
+    "watchVideo": "https://demo-reduwyf2ra-uc.a.run.app/demo#recording-proof",
+    "playWithData": "https://demo-reduwyf2ra-uc.a.run.app/demo#live-operations",
+    "releaseReceipts": "https://demo-reduwyf2ra-uc.a.run.app/demo#evidence-proof"
+  },
+  "assets": {
+    "manifest": "https://demo-reduwyf2ra-uc.a.run.app/demo/assets/demo-manifest.json",
+    "config": "https://demo-reduwyf2ra-uc.a.run.app/demo/demo-config.js?v=20260326b",
+    "stylesheet": "https://demo-reduwyf2ra-uc.a.run.app/demo/assets/demo.css?v=20260326b",
+    "script": "https://demo-reduwyf2ra-uc.a.run.app/demo/assets/demo.js?v=20260326b",
+    "favicon": "https://demo-reduwyf2ra-uc.a.run.app/demo/assets/favicon.svg?v=20260326b",
+    "videoMp4": null,
+    "videoPoster": null,
+    "demoDownload": null,
+    "sampleData": null,
+    "releaseReceiptsJson": null
+  },
+  "assetPolicy": {
+    "directBinaryAssetsRequiredForFinalInlineEmbed": [
+      "videoMp4",
+      "demoDownload",
+      "sampleData"
+    ],
+    "currentFallbacks": {
+      "videoMp4": "sections.watchVideo",
+      "demoDownload": "sections.releaseReceipts",
+      "sampleData": "sections.playWithData"
+    },
+    "noSecrets": true,
+    "publicSafe": true,
+    "privateServicesExposed": false
+  },
+  "squarespace": {
+    "bridgePage": "https://www.fractal5solutions.com/demo-1",
+    "canonReference": "https://www.fractal5solutions.com/launch",
+    "embedMode": "single-code-block-with-remote-runtime-assets"
+  },
+  "claimControl": {
+    "rawCloudRunDemoPublicGreen": true,
+    "assetManifestSourceCreated": true,
+    "assetManifestCloudRunLiveConfirmed": false,
+    "fullCommercialGreenAllowed": false,
+    "reason": "Direct binary URLs for MP4, downloadable package, and sample-data asset must be generated and public-verified before claiming asset-complete /demo-1."
+  }
+}

--- a/demo/assets/demo-manifest.json
+++ b/demo/assets/demo-manifest.json
@@ -19,7 +19,8 @@
     "releaseReceipts": "https://demo-reduwyf2ra-uc.a.run.app/demo#evidence-proof"
   },
   "assets": {
-    "manifest": "https://demo-reduwyf2ra-uc.a.run.app/demo/assets/demo-manifest.json",
+    "manifest": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/demo/assets/demo-manifest.json",
+    "cloudRunManifest": null,
     "videoMp4": null,
     "videoPoster": null,
     "demoDownload": null,
@@ -27,9 +28,6 @@
     "releaseReceiptsJson": null
   },
   "assetPolicy": {
-    "servedAssetRoutes": [
-      "/demo/assets/demo-manifest.json"
-    ],
     "directBinaryAssetsRequiredForFinalInlineEmbed": [
       "videoMp4",
       "demoDownload",


### PR DESCRIPTION
Adds the public demo asset manifest for /demo-1 integration. This records live Cloud Run demo routes, proof sections, runtime assets, and explicit claim-control guardrails for missing direct binary assets.