### PR TITLE
Generate public demo assets and formalize demo-1 contract

### DIFF
--- a/DEMO_1_DELIVERY_CONTRACT.md
+++ b/DEMO_1_DELIVERY_CONTRACT.md
@@ -1,0 +1,131 @@
+# /demo-1 Delivery Contract
+
+Status: canonical public bridge contract for the Fractal5 Solutions `/demo-1` page.
+
+## Purpose
+
+`https://www.fractal5solutions.com/demo-1` is the live public Squarespace target page for Dominion OS 1.0 demo delivery.
+
+The page must present a beautiful, Canon-aligned public experience that lets a visitor:
+
+1. open the live Dominion OS Cloud Run demo,
+2. watch the demo video or video-equivalent runtime section,
+3. play with public-safe demo data online,
+4. inspect health/status proof,
+5. open or download public-safe demo receipts/assets,
+6. request client access through Fractal5 Solutions.
+
+`/demo-1` is the visitor-facing bridge. It is not the private runtime, not the source repository, and not the place where secrets or internal APIs live.
+
+## Canon roles
+
+- `/demo-1`: public Squarespace bridge and sales/demo page.
+- `dominion-os-demo-build`: public source-of-truth for demo-build public artifacts.
+- Cloud Run demo: live runtime source at `https://demo-reduwyf2ra-uc.a.run.app/demo`.
+- `Fractal5-Solutions/phi-ops`: operational daemon/evidence layer for public route probes and daily readiness packets.
+- Dominion Command Center: executive control-plane memory and decision ledger.
+
+## Required public routes
+
+These routes must remain public and working for `/demo-1` delivery:
+
+- `https://demo-reduwyf2ra-uc.a.run.app/`
+- `https://demo-reduwyf2ra-uc.a.run.app/demo`
+- `https://demo-reduwyf2ra-uc.a.run.app/health`
+- `https://demo-reduwyf2ra-uc.a.run.app/status`
+- `https://www.fractal5solutions.com/demo-1`
+
+## Required source-served assets
+
+The following source-served assets are public-safe and may be consumed by `/demo-1` as remote runtime assets:
+
+- `demo/assets/demo-manifest.json`
+- `demo/assets/dominion-os-demo-poster.svg`
+- `demo/assets/sample-data.json`
+
+Additional public assets should be added only when they are real, generated, and verified:
+
+- direct MP4 recording file,
+- downloadable demo package,
+- direct release receipts JSON,
+- poster image variants.
+
+Do not advertise a direct asset URL in the manifest unless the file exists and can be fetched publicly.
+
+## Required visitor actions
+
+`/demo-1` must expose the following visitor actions:
+
+- Open Live Demo -> Cloud Run `/demo`
+- Watch Video -> Cloud Run `/demo#recording-proof` or direct MP4 when available
+- Play With Data -> Cloud Run `/demo#live-operations` or public sample data when available
+- Open Receipts -> Cloud Run `/demo#evidence-proof` or public receipt JSON when available
+- Health -> Cloud Run `/health`
+- Status -> Cloud Run `/status`
+- Request Client Access -> Fractal5 contact or member/customer path
+
+## Continuous verification requirements
+
+The system must continuously watch:
+
+- `/demo-1` page availability,
+- Cloud Run root/demo/health/status routes,
+- demo manifest availability,
+- source-served demo assets,
+- stale bridge detection: `/demo-1` must reference the current live demo route or approved branded runtime URL,
+- secret/private marker detection in public content,
+- dependency/security alerts in operational repos,
+- evidence packet publication.
+
+The current installed watchers are:
+
+- ChatGPT hourly live demo health watcher,
+- ChatGPT daily commercial launch readiness audit,
+- GitHub-native hourly public probe daemon in `Fractal5-Solutions/phi-ops`,
+- GitHub-native daily evidence packet daemon in `Fractal5-Solutions/phi-ops`.
+
+Native GCP Scheduler / Cloud Run Job self-healing remains a desired next body unless separately proven installed.
+
+## Public safety boundaries
+
+`/demo-1` must never expose:
+
+- production customer data,
+- private API endpoints,
+- signing keys,
+- payment secrets,
+- source code beyond approved public demo-build artifacts,
+- internal operational dashboards,
+- private Cloud Run services.
+
+Private services must remain authenticated or otherwise intentionally controlled.
+
+## Claim control
+
+Allowed claim today:
+
+> Dominion OS 1.0 has a live public Google Cloud demo surface with public demo, health, and status routes and a watched public Squarespace bridge.
+
+Not allowed without additional evidence:
+
+> Full SaaS commerce, direct MP4/package downloads, production customer portal, branded runtime domain, and native GCP self-healing are completely green.
+
+Those claims require separate receipts.
+
+## Acceptance criteria for `/demo-1` perfection
+
+`/demo-1` is green only when:
+
+1. the Squarespace page loads cleanly,
+2. it follows Fractal5 Canon visual language from `/launch`,
+3. all CTAs resolve to working public routes,
+4. all referenced assets exist and are public-safe,
+5. health/status proof is available,
+6. no stale or false asset claims exist,
+7. the watcher daemon confirms the page and routes continuously,
+8. the page does not expose private information,
+9. visitors can watch, play, inspect, and request access without manual explanation.
+
+## Current truth
+
+The `/demo-1` contract is formalized here. The live demo routes are proven by operator output. The manifest is merged to `dominion-os-demo-build` main. Generated poster and sample-data assets are in progress on the asset branch. Direct MP4 and direct downloadable package must not be claimed until real files are generated and publicly verified.

--- a/demo/assets/demo-manifest.json
+++ b/demo/assets/demo-manifest.json
@@ -22,21 +22,25 @@
     "manifest": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/demo/assets/demo-manifest.json",
     "cloudRunManifest": null,
     "videoMp4": null,
-    "videoPoster": null,
+    "videoPoster": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/demo/assets/dominion-os-demo-poster.svg",
     "demoDownload": null,
-    "sampleData": null,
+    "sampleData": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/demo/assets/sample-data.json",
     "releaseReceiptsJson": null
   },
   "assetPolicy": {
+    "sourceServedAssets": [
+      "assets.manifest",
+      "assets.videoPoster",
+      "assets.sampleData"
+    ],
     "directBinaryAssetsRequiredForFinalInlineEmbed": [
       "videoMp4",
-      "demoDownload",
-      "sampleData"
+      "demoDownload"
     ],
     "currentFallbacks": {
       "videoMp4": "sections.watchVideo",
       "demoDownload": "sections.releaseReceipts",
-      "sampleData": "sections.playWithData"
+      "releaseReceiptsJson": "sections.releaseReceipts"
     },
     "noSecrets": true,
     "publicSafe": true,
@@ -50,8 +54,9 @@
   "claimControl": {
     "rawCloudRunDemoPublicGreen": true,
     "assetManifestSourceCreated": true,
+    "sourceServedAssetsPublished": true,
     "assetManifestCloudRunLiveConfirmed": false,
     "fullCommercialGreenAllowed": false,
-    "reason": "Direct binary URLs for MP4, downloadable package, and sample-data asset must be generated and public-verified before claiming asset-complete /demo-1."
+    "reason": "Generated poster and sample-data assets are source-served through the manifest. Direct binary MP4 and downloadable package URLs remain null until real files are generated and publicly verified."
   }
 }

--- a/demo/assets/dominion-os-demo-poster.svg
+++ b/demo/assets/dominion-os-demo-poster.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+  <title id="title">Dominion OS 1.0 Live Demo Poster</title>
+  <desc id="desc">Fractal5 Solutions Dominion OS live cloud demo poster in black, ivory, graphite, and gold.</desc>
+  <defs>
+    <linearGradient id="paper" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#fbfaf8"/>
+      <stop offset="0.55" stop-color="#f5f2ec"/>
+      <stop offset="1" stop-color="#ffffff"/>
+    </linearGradient>
+    <linearGradient id="ink" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#050506"/>
+      <stop offset="1" stop-color="#242424"/>
+    </linearGradient>
+    <radialGradient id="goldGlow" cx="18%" cy="8%" r="55%">
+      <stop offset="0" stop-color="#b08a3c" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#b08a3c" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#e6e1d7" stroke-width="1" opacity="0.75"/>
+    </pattern>
+  </defs>
+  <rect width="1600" height="900" fill="url(#paper)"/>
+  <rect width="1600" height="900" fill="url(#goldGlow)"/>
+  <rect width="1600" height="900" fill="url(#grid)" opacity="0.42"/>
+  <rect x="92" y="84" width="1416" height="732" rx="34" fill="#ffffff" stroke="#e6e1d7" stroke-width="2"/>
+  <rect x="132" y="124" width="220" height="42" rx="21" fill="url(#ink)"/>
+  <text x="160" y="152" font-family="system-ui, -apple-system, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#ffffff" letter-spacing="3">LIVE GCLOUD DEMO</text>
+  <text x="132" y="310" font-family="system-ui, -apple-system, Segoe UI, Arial, sans-serif" font-size="106" font-weight="800" fill="#0b0b0c" letter-spacing="-5">Dominion OS</text>
+  <text x="132" y="424" font-family="system-ui, -apple-system, Segoe UI, Arial, sans-serif" font-size="94" font-weight="800" fill="#0b0b0c" letter-spacing="-5">live on the cloud.</text>
+  <text x="136" y="502" font-family="system-ui, -apple-system, Segoe UI, Arial, sans-serif" font-size="30" fill="#5f5a52">A Fractal5 demo bridge into video, sandbox data, status, health, and release receipts.</text>
+  <g transform="translate(126,604)">
+    <rect x="0" y="0" width="285" height="72" rx="36" fill="#fbfaf8" stroke="#b08a3c" stroke-width="2"/>
+    <text x="42" y="45" font-family="system-ui, -apple-system, Segoe UI, Arial, sans-serif" font-size="20" font-weight="800" fill="#0b0b0c" letter-spacing="2">OPEN LIVE DEMO</text>
+  </g>
+  <g transform="translate(1030,180)">
+    <rect x="0" y="0" width="362" height="440" rx="28" fill="#fbfaf8" stroke="#e6e1d7" stroke-width="2"/>
+    <circle cx="68" cy="74" r="10" fill="#137a3d"/>
+    <text x="96" y="82" font-family="system-ui, -apple-system, Segoe UI, Arial, sans-serif" font-size="20" font-weight="800" fill="#0b0b0c">Demo route: 200</text>
+    <circle cx="68" cy="144" r="10" fill="#137a3d"/>
+    <text x="96" y="152" font-family="system-ui, -apple-system, Segoe UI, Arial, sans-serif" font-size="20" font-weight="800" fill="#0b0b0c">Health JSON</text>
+    <circle cx="68" cy="214" r="10" fill="#137a3d"/>
+    <text x="96" y="222" font-family="system-ui, -apple-system, Segoe UI, Arial, sans-serif" font-size="20" font-weight="800" fill="#0b0b0c">Status JSON</text>
+    <circle cx="68" cy="284" r="10" fill="#137a3d"/>
+    <text x="96" y="292" font-family="system-ui, -apple-system, Segoe UI, Arial, sans-serif" font-size="20" font-weight="800" fill="#0b0b0c">Daemon watched</text>
+    <line x1="52" y1="340" x2="310" y2="340" stroke="#e6e1d7" stroke-width="2"/>
+    <text x="52" y="386" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="16" fill="#5f5a52">/demo-1 → Cloud Run /demo</text>
+  </g>
+  <text x="132" y="762" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="18" fill="#5f5a52">Fractal5 Solutions · Sovereignty-first systems · Policy → provable automation</text>
+</svg>

--- a/demo/assets/sample-data.json
+++ b/demo/assets/sample-data.json
@@ -1,0 +1,64 @@
+{
+  "schema": "f5.dominion.demo.sample-data.v1",
+  "generatedAt": "2026-06-07T00:00:00Z",
+  "environment": "demo-sandbox",
+  "purpose": "Public-safe sample data for /demo-1 visitors to understand the Dominion OS live demo without exposing production data.",
+  "datasets": [
+    {
+      "id": "business-ops-signal",
+      "name": "Business Operations Signal",
+      "domain": "business",
+      "records": [
+        {
+          "timestamp": "2026-06-07T13:36:26Z",
+          "signal": "demo_route_green",
+          "route": "/demo",
+          "status": 200,
+          "evidence": "Public Cloud Run demo route verified by operator proof."
+        },
+        {
+          "timestamp": "2026-06-07T13:42:32Z",
+          "signal": "health_json_green",
+          "route": "/health",
+          "status": 200,
+          "evidence": "Public health endpoint returned JSON metadata."
+        },
+        {
+          "timestamp": "2026-06-07T13:42:32Z",
+          "signal": "status_json_green",
+          "route": "/status",
+          "status": 200,
+          "evidence": "Public status endpoint returned hardening and runtime metadata."
+        }
+      ]
+    },
+    {
+      "id": "politics-demo-signal",
+      "name": "Politics Demo Signal",
+      "domain": "politics",
+      "records": [
+        {
+          "jurisdiction": "sample-canada",
+          "workflow": "policy-to-proof",
+          "input": "sample public policy objective",
+          "output": "sample auditable decision packet",
+          "classification": "public-demo-placeholder"
+        },
+        {
+          "jurisdiction": "sample-usa",
+          "workflow": "campaign-ops-governance",
+          "input": "sample civic operations task",
+          "output": "sample controlled execution receipt",
+          "classification": "public-demo-placeholder"
+        }
+      ]
+    }
+  ],
+  "safety": {
+    "containsProductionData": false,
+    "containsCustomerData": false,
+    "containsSecrets": false,
+    "containsPaymentData": false,
+    "publicSafe": true
+  }
+}


### PR DESCRIPTION
Adds the first public-safe generated asset layer for `/demo-1` and records the canonical delivery contract.

Included:

- `demo/assets/dominion-os-demo-poster.svg`
- `demo/assets/sample-data.json`
- `DEMO_1_DELIVERY_CONTRACT.md`

Purpose:

- Make `/demo-1` the live public Squarespace bridge.
- Keep Cloud Run `/demo` as the runtime source.
- Make the interconnection map durable for AI/operator/daemon systems.
- Clarify continuous verification requirements and claim-control boundaries.

Not claimed yet:

- Direct MP4 binary.
- Direct downloadable ZIP/package.
- Production commerce/customer portal green.
- Native GCP Scheduler/Cloud Run Job self-healing green.

Those must be generated and publicly verified before the `/demo-1` page can truthfully advertise them as direct assets.