### PR TITLE
Add commercial launch readiness gates for Dominion OS demo

### DIFF
--- a/demo/assets/commercial-launch-readiness.json
+++ b/demo/assets/commercial-launch-readiness.json
@@ -1,0 +1,122 @@
+{
+  "schema": "f5.dominion.commercial-launch-readiness.v1",
+  "generatedAt": "2026-06-18T00:00:00Z",
+  "sourceOfTruth": {
+    "repository": "Fractal5-Solutions/dominion-os-demo-build",
+    "path": "demo/assets/commercial-launch-readiness.json",
+    "environment": "demo-sandbox",
+    "publicSurface": "https://www.fractal5solutions.com/demo-1"
+  },
+  "overallStatus": "AMBER",
+  "summary": "Dominion OS is public-demo ready and controlled prospect-share ready. Full commercial launch remains blocked until commerce, customer portal, production observability, autonomous remediation, and client-safe payment/provisioning receipts exist.",
+  "statusMatrix": [
+    {
+      "area": "demo-runtime",
+      "status": "GREEN",
+      "currentEvidence": [
+        "Cloud Run demo route is the canonical public runtime target.",
+        "Health and status JSON routes are required by the /demo-1 delivery contract.",
+        "Operator receipts exist in demo/assets/release-receipts.json."
+      ],
+      "greenGate": "Public /demo, /health, and /status probes pass from the daemon/watchlist layer."
+    },
+    {
+      "area": "hardened-website-bridge",
+      "status": "AMBER",
+      "currentEvidence": [
+        "squarespace/demo-1-final.html is the source bridge package.",
+        "DEMO_1_POST_PUBLISH_VERIFICATION.md defines the live-DOM pass criteria."
+      ],
+      "greenGate": "The deployed Squarespace /demo-1 DOM returns HTTP 200 and contains all required strings, CTAs, referrer/link hardening, manifest allowlist, and Canon Light styling."
+    },
+    {
+      "area": "source-served-assets",
+      "status": "GREEN",
+      "currentEvidence": [
+        "demo-manifest.json, sample-data.json, demo-download-package.json, release-receipts.json, and watchlist artifacts are source-served.",
+        "direct MP4 remains null by design."
+      ],
+      "greenGate": "All source-served public assets return HTTP 200 with expected content types from the watchlist daemon."
+    },
+    {
+      "area": "security",
+      "status": "AMBER",
+      "currentEvidence": [
+        "Public demo assets assert no secrets, customer data, payment data, or private services.",
+        "Public bridge is intended to expose only approved public demo-build artifacts."
+      ],
+      "greenGate": "Secret scanning, dependency scanning, tenant-isolation proof, and public-boundary review receipts exist for the public release path."
+    },
+    {
+      "area": "build-test",
+      "status": "AMBER",
+      "currentEvidence": [
+        "PR #127 added public watchlist and post-publish verification scaffolding.",
+        "Existing checks prove the verification layer, not full commercial production qualification."
+      ],
+      "greenGate": "Current CI, link checks, asset checks, public-boundary checks, and e2e bridge checks pass on the release candidate."
+    },
+    {
+      "area": "cloud-health",
+      "status": "GREEN",
+      "currentEvidence": [
+        "Cloud Run root/demo/health/status routes are required public routes in the delivery contract.",
+        "release-receipts.json marks those routes as operator-verified."
+      ],
+      "greenGate": "Hourly daemon probes confirm current route health and publish receipts."
+    },
+    {
+      "area": "commerce-customer-portal",
+      "status": "RED",
+      "currentEvidence": [
+        "No public proof of checkout, customer portal, subscription, billing, tenant provisioning, or entitlement lifecycle is present in demo-build."
+      ],
+      "greenGate": "Live or deliberately invoice-only commercial intake is documented with payment/procurement, onboarding, entitlement, support, refund, and privacy receipts."
+    },
+    {
+      "area": "observability",
+      "status": "AMBER",
+      "currentEvidence": [
+        "Health/status endpoints exist.",
+        "No durable public proof of uptime checks, alert routing, SLOs, incident receipts, traces, or metrics retention is present in demo-build."
+      ],
+      "greenGate": "Uptime, alerting, log-sampling, incident response, and rollback receipts are generated and stored without exposing secrets."
+    },
+    {
+      "area": "autonomous-operations",
+      "status": "AMBER",
+      "currentEvidence": [
+        "Delivery contract names phi-ops as the operational daemon/evidence layer.",
+        "Native GCP self-healing is explicitly not allowed as a claim without separate proof."
+      ],
+      "greenGate": "Watcher ingestion, autonomous remediation, rollback/recovery, and self-healing receipts exist and can be audited."
+    }
+  ],
+  "claimControl": {
+    "allowedNow": [
+      "Dominion OS has a live public Google Cloud demo surface with public demo, health, and status routes, a canonical /demo-1 bridge package, source-served public demo assets, sample data, release receipts, and a watchlist verification layer."
+    ],
+    "notAllowedWithoutSeparateReceipts": [
+      "full SaaS commerce is green",
+      "customer portal is green",
+      "direct MP4 is available",
+      "native GCP self-healing is green",
+      "production observability is green",
+      "full commercial stack is 100% green"
+    ],
+    "directMp4CurrentlyAvailable": false,
+    "fullCommercialGreenCurrentlyAllowed": false
+  },
+  "requiredReceiptsForFullCommercialGreen": [
+    "deployed /demo-1 live-DOM verification receipt",
+    "daemon watchlist ingestion receipt",
+    "hourly probe output for /demo-1, Cloud Run routes, and raw assets",
+    "secret/public-boundary scan receipt",
+    "current CI/build/test receipt",
+    "commerce or invoice-only sales-motion receipt",
+    "customer onboarding and entitlement receipt",
+    "observability and alert-routing receipt",
+    "rollback and incident-response receipt",
+    "autonomous remediation/self-healing receipt if that claim is made"
+  ]
+}

--- a/demo/assets/demo-1-watchlist.json
+++ b/demo/assets/demo-1-watchlist.json
@@ -1,6 +1,6 @@
 {
   "schema": "f5.demo1.watchlist.v1",
-  "generatedAt": "2026-06-07T00:00:00Z",
+  "generatedAt": "2026-06-18T00:00:00Z",
   "page": {
     "name": "Fractal5 /demo-1",
     "url": "https://www.fractal5solutions.com/demo-1",
@@ -19,7 +19,13 @@
     "sampleData": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/demo/assets/sample-data.json",
     "demoPackage": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/demo/assets/demo-download-package.json",
     "releaseReceipts": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/demo/assets/release-receipts.json",
-    "squarespaceCode": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/squarespace/demo-1-final.html"
+    "squarespaceCode": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/squarespace/demo-1-final.html",
+    "commercialLaunchReadiness": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/demo/assets/commercial-launch-readiness.json"
+  },
+  "documentation": {
+    "deliveryContract": "DEMO_1_DELIVERY_CONTRACT.md",
+    "postPublishVerification": "DEMO_1_POST_PUBLISH_VERIFICATION.md",
+    "commercialLaunchGreenGates": "docs/launch-readiness/2026-06-18-commercial-launch-green-gates.md"
   },
   "expectedStatus": {
     "html": 200,
@@ -38,10 +44,23 @@
     "page contains Open Receipts",
     "page contains Contact Fractal5"
   ],
+  "commercialGreenGates": [
+    "deployed /demo-1 live-DOM verification receipt",
+    "daemon watchlist ingestion receipt",
+    "hourly probe output for /demo-1, Cloud Run routes, and raw assets",
+    "secret/public-boundary scan receipt",
+    "current CI/build/test receipt",
+    "commerce or invoice-only sales-motion receipt",
+    "customer onboarding and entitlement receipt",
+    "observability and alert-routing receipt",
+    "rollback and incident-response receipt",
+    "autonomous remediation/self-healing receipt if that claim is made"
+  ],
   "claimControl": {
     "directMp4RequiredForMp4Claim": true,
     "directMp4CurrentlyAvailable": false,
     "fullCommerceGreenCurrentlyAllowed": false,
-    "reason": "The public bridge and source-served assets are ready. Direct MP4, commerce, native GCP self-healing, and production client portal proof require separate receipts."
+    "fullCommercialGreenCurrentlyAllowed": false,
+    "reason": "The public bridge and source-served assets are ready. Direct MP4, commerce, native GCP self-healing, production observability, and production client portal proof require separate receipts."
   }
 }

--- a/docs/launch-readiness/2026-06-18-commercial-launch-green-gates.md
+++ b/docs/launch-readiness/2026-06-18-commercial-launch-green-gates.md
@@ -1,0 +1,63 @@
+# Dominion OS commercial launch green gates — 2026-06-18
+
+Status: AMBER
+
+This receipt converts the public launch-readiness audit into operational gates. It is intentionally conservative: the public demo may be strong while the commercial launch remains incomplete.
+
+## Current truth
+
+Dominion OS has a credible public demo spine:
+
+- canonical public bridge target: `https://www.fractal5solutions.com/demo-1`
+- public Cloud Run runtime target: `https://demo-reduwyf2ra-uc.a.run.app/demo`
+- public health/status route requirements
+- source-served demo manifest, sample data, demo package manifest, release receipts, poster asset, and watchlist artifacts
+- PR #127 merged the `/demo-1` watchlist and post-publish verification layer
+
+Commercial launch is not fully green until separate receipts prove commerce, customer portal, production observability, autonomous remediation, and client-safe payment/provisioning boundaries.
+
+## Status matrix
+
+| Area | Status | Gate to green |
+| --- | --- | --- |
+| Demo runtime | GREEN | Daemon confirms root/demo/health/status probes pass. |
+| Hardened website bridge | AMBER | Live Squarespace `/demo-1` DOM passes the full post-publish checklist. |
+| Source-served assets | GREEN | Manifest, poster, sample data, package JSON, and release receipts return expected public content types. |
+| Security | AMBER | Secret scan, dependency scan, public-boundary review, and tenant-isolation proof exist. |
+| Build/test | AMBER | Current CI, link checks, public-boundary checks, and e2e bridge checks pass on release candidate. |
+| Cloud health | GREEN | Hourly route probes publish durable receipts. |
+| Commerce/customer portal | RED | Live or deliberately invoice-only sales motion is proven with onboarding, entitlement, support, refund, privacy, and payment/procurement receipts. |
+| Observability | AMBER | Uptime, alerting, log sampling, SLO/incident, and rollback receipts exist. |
+| Autonomous operations | AMBER | Watcher ingestion, remediation, rollback/recovery, and self-healing receipts exist before those claims are made. |
+
+## Allowed claim now
+
+Dominion OS has a live public Google Cloud demo surface with public demo, health, and status routes, a canonical `/demo-1` bridge package, source-served public demo assets, sample data, release receipts, and a watchlist verification layer.
+
+## Not allowed without separate receipts
+
+Do not claim any of the following until the relevant receipt exists:
+
+- full SaaS commerce is green
+- customer portal is green
+- direct MP4 is available
+- native GCP self-healing is green
+- production observability is green
+- full commercial stack is 100% green
+
+## Required receipts for full commercial green
+
+1. Deployed `/demo-1` live-DOM verification receipt.
+2. Daemon watchlist ingestion receipt.
+3. Hourly probe output for `/demo-1`, Cloud Run routes, and raw assets.
+4. Secret/public-boundary scan receipt.
+5. Current CI/build/test receipt.
+6. Commerce or invoice-only sales-motion receipt.
+7. Customer onboarding and entitlement receipt.
+8. Observability and alert-routing receipt.
+9. Rollback and incident-response receipt.
+10. Autonomous remediation/self-healing receipt if that claim is made.
+
+## Operator note
+
+The bridge is not the cathedral. The bridge gets prospects safely across the river. Commerce, portal, observability, and autonomous operations are the stonework that makes it a city.


### PR DESCRIPTION
## Purpose

Turns the current Dominion OS commercial launch readiness assessment into durable, public-safe demo-build artifacts.

## Adds

- `demo/assets/commercial-launch-readiness.json`
- `docs/launch-readiness/2026-06-18-commercial-launch-green-gates.md`

## Updates

- `demo/assets/demo-1-watchlist.json`
  - adds the commercial launch readiness artifact
  - adds the human-readable green-gates document
  - preserves the existing /demo-1 string and route checks
  - strengthens claim control for direct MP4, commerce, production observability, customer portal, and native self-healing

## Claim control

This PR does **not** claim full commercial green.

It explicitly preserves the current truth:

- public demo/prospect bridge: strong
- commerce/customer portal: not proven
- direct MP4: not available
- production observability: not proven
- autonomous remediation/native self-healing: not proven

## Required next receipts before full commercial green

- live deployed /demo-1 DOM verification
- daemon watchlist ingestion
- hourly public route and raw asset probes
- secret/public-boundary scan
- current CI/build/test pass
- commerce or invoice-only sales motion receipt
- onboarding and entitlement receipt
- observability and alert routing receipt
- rollback and incident response receipt
- autonomous remediation/self-healing receipt, if claimed

No secrets. No customer data. No payment data. No source exposure beyond approved public demo-build artifacts.