### PR TITLE
Execute NHITL commercial unblock probe layer

### DIFF
--- a/.github/workflows/demo1-public-proof.yml
+++ b/.github/workflows/demo1-public-proof.yml
@@ -1,0 +1,42 @@
+name: demo1-public-proof
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 * * * *'
+  pull_request:
+    paths:
+      - 'demo/assets/**'
+      - 'squarespace/demo-1-final.html'
+      - 'tools/verify-demo1-public-proof.mjs'
+      - '.github/workflows/demo1-public-proof.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  public-proof:
+    name: Public proof receipt
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run public proof verifier
+        env:
+          PROBE_STRICT: 'false'
+          OUT_DIR: out/demo1-public-proof
+        run: node tools/verify-demo1-public-proof.mjs
+
+      - name: Upload probe receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo1-public-proof-receipt
+          path: out/demo1-public-proof/latest-probe.json
+          if-no-files-found: error

--- a/demo/assets/controlled-preview-commerce-receipt.json
+++ b/demo/assets/controlled-preview-commerce-receipt.json
@@ -1,0 +1,35 @@
+{
+  "schema": "f5.dominion.controlled-preview-commerce-receipt.v1",
+  "generatedAt": "2026-07-06T00:45:00Z",
+  "status": "AMBER",
+  "commercialMode": "controlled-preview-invoice-only",
+  "summary": "Controlled commercial preview is allowed through direct Fractal5 contact and invoice/procurement handling. This is not self-serve SaaS checkout and does not prove a customer portal, automated billing, or subscription entitlement lifecycle.",
+  "allowedNow": [
+    "Prospect receives canonical /demo-1 bridge and public proof assets.",
+    "Prospect requests access through Fractal5 contact path.",
+    "Fractal5 may handle qualification, statement of work, invoice/procurement, onboarding, and controlled access manually."
+  ],
+  "notAllowedToClaim": [
+    "self-serve checkout is live",
+    "customer portal is green",
+    "subscription billing is automated",
+    "tenant provisioning is automated and receipted",
+    "payment processor production flow is proven",
+    "full SaaS commerce is green"
+  ],
+  "requiredReceiptsForGreen": [
+    "approved offer/pricing sheet or quote template",
+    "invoice/procurement receipt or checkout/payment receipt",
+    "customer onboarding/provisioning receipt",
+    "entitlement lifecycle receipt",
+    "support path receipt",
+    "refund/cancellation/offboarding receipt",
+    "privacy/data-processing receipt"
+  ],
+  "claimControl": {
+    "controlledPreviewCommercialUseAllowed": true,
+    "selfServeCommerceGreenAllowed": false,
+    "customerPortalGreenAllowed": false,
+    "fullCommercialGreenAllowed": false
+  }
+}

--- a/demo/assets/demo-1-watchlist.json
+++ b/demo/assets/demo-1-watchlist.json
@@ -1,6 +1,6 @@
 {
   "schema": "f5.demo1.watchlist.v1",
-  "generatedAt": "2026-06-18T00:00:00Z",
+  "generatedAt": "2026-07-06T00:45:00Z",
   "page": {
     "name": "Fractal5 /demo-1",
     "url": "https://www.fractal5solutions.com/demo-1",
@@ -20,12 +20,14 @@
     "demoPackage": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/demo/assets/demo-download-package.json",
     "releaseReceipts": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/demo/assets/release-receipts.json",
     "squarespaceCode": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/squarespace/demo-1-final.html",
-    "commercialLaunchReadiness": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/demo/assets/commercial-launch-readiness.json"
+    "commercialLaunchReadiness": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/demo/assets/commercial-launch-readiness.json",
+    "controlledPreviewCommerce": "https://raw.githubusercontent.com/Fractal5-Solutions/dominion-os-demo-build/main/demo/assets/controlled-preview-commerce-receipt.json"
   },
   "documentation": {
     "deliveryContract": "DEMO_1_DELIVERY_CONTRACT.md",
     "postPublishVerification": "DEMO_1_POST_PUBLISH_VERIFICATION.md",
-    "commercialLaunchGreenGates": "docs/launch-readiness/2026-06-18-commercial-launch-green-gates.md"
+    "commercialLaunchGreenGates": "docs/launch-readiness/2026-06-18-commercial-launch-green-gates.md",
+    "nhitlExecutionReceipt": "docs/launch-readiness/2026-07-06-nhitl-unblock-execution.md"
   },
   "expectedStatus": {
     "html": 200,
@@ -33,23 +35,44 @@
     "svg": 200
   },
   "requiredAssertions": [
-    "page contains Dominion OS, live on the cloud.",
-    "page contains Open Live Demo",
-    "page contains Watch Video",
-    "page contains Play With Data",
-    "page contains Health JSON",
-    "page contains Status JSON",
-    "page contains View Sample Data",
-    "page contains Open Demo Package",
-    "page contains Open Receipts",
-    "page contains Contact Fractal5"
+    "Dominion OS, live on the cloud.",
+    "Open Live Demo",
+    "Watch Video",
+    "Play With Data",
+    "Health JSON",
+    "Status JSON",
+    "View Sample Data",
+    "Open Demo Package",
+    "Open Receipts",
+    "Contact Fractal5"
   ],
+  "requiredHardeningAssertions": [
+    "data-version=\"2026-06-08-hardened\"",
+    "rel=\"noopener noreferrer\"",
+    "referrerpolicy=\"strict-origin-when-cross-origin\"",
+    "hidden referrerpolicy=\"strict-origin-when-cross-origin\"",
+    "ALLOWED_RUNTIME_ORIGIN",
+    "ALLOWED_RAW_ASSETS_PREFIX",
+    "ALLOWED_FRACTAL5_URLS"
+  ],
+  "claimDriftChecks": {
+    "forbiddenWhenManifestVideoMp4Null": [
+      "Actual demo MP4 integrated",
+      "Open web MP4",
+      "Open master MP4",
+      "direct MP4 is available",
+      "MP4 integrated"
+    ],
+    "manifestVideoMp4Path": "assets.videoMp4",
+    "allowedFallbackWhenNull": "sections.watchVideo"
+  },
   "commercialGreenGates": [
     "deployed /demo-1 live-DOM verification receipt",
+    "claim-drift repair receipt for /demo MP4 language versus manifest",
     "daemon watchlist ingestion receipt",
     "hourly probe output for /demo-1, Cloud Run routes, and raw assets",
     "secret/public-boundary scan receipt",
-    "current CI/build/test receipt",
+    "current CI/build/test/e2e receipt",
     "commerce or invoice-only sales-motion receipt",
     "customer onboarding and entitlement receipt",
     "observability and alert-routing receipt",
@@ -61,6 +84,7 @@
     "directMp4CurrentlyAvailable": false,
     "fullCommerceGreenCurrentlyAllowed": false,
     "fullCommercialGreenCurrentlyAllowed": false,
-    "reason": "The public bridge and source-served assets are ready. Direct MP4, commerce, native GCP self-healing, production observability, and production client portal proof require separate receipts."
+    "controlledPreviewCommercialUseAllowed": true,
+    "reason": "The public bridge and source-served assets support controlled preview sharing. Direct MP4, full self-serve commerce, native GCP self-healing, production observability, and production customer portal proof require separate receipts."
   }
 }

--- a/docs/launch-readiness/2026-07-06-nhitl-unblock-execution.md
+++ b/docs/launch-readiness/2026-07-06-nhitl-unblock-execution.md
@@ -1,0 +1,72 @@
+# Dominion OS NHITL Commercial Unblock Execution — 2026-07-06
+
+Generated: 2026-07-06T00:45:00Z  
+Mode: NHITL execution with public-safe guardrails  
+Primary tracker: Issue #145  
+Repository: Fractal5-Solutions/dominion-os-demo-build
+
+## Execution verdict
+
+The unblock plan is now executable, not merely descriptive.
+
+This package adds a machine-readable public proof verifier, a scheduled/manual GitHub Actions workflow, stronger watchlist assertions, and a controlled-preview commerce receipt.
+
+The commercial state remains AMBER. Controlled commercial preview is allowed. Full commercial green remains blocked.
+
+## What changed
+
+1. Added `tools/verify-demo1-public-proof.mjs`.
+2. Added `.github/workflows/demo1-public-proof.yml`.
+3. Strengthened `demo/assets/demo-1-watchlist.json` with:
+   - hardened bridge assertions,
+   - claim-drift checks for MP4 language,
+   - controlled-preview commerce receipt route,
+   - NHITL execution document reference.
+4. Added `demo/assets/controlled-preview-commerce-receipt.json`.
+5. Preserved full-commercial-green claim control.
+
+## Probe behavior
+
+The verifier fetches only public URLs declared in the watchlist and manifest. It checks:
+
+- `/demo-1`, `/demo`, `/health`, `/status`;
+- source-served manifest, poster, sample data, package, receipts, bridge source, readiness, and commerce receipt;
+- expected HTTP 200 status;
+- basic content-type posture;
+- required `/demo-1` visible strings;
+- hardened bridge strings such as `data-version="2026-06-08-hardened"`, noreferrer, referrer policy, hidden poster fallback, and allowlist constants;
+- forbidden MP4-complete language while `assets.videoMp4` remains null.
+
+The workflow runs hourly and manually. It uploads a public-safe JSON artifact named `demo1-public-proof-receipt`.
+
+## Commercial interpretation
+
+The new commerce receipt deliberately chooses the fastest honest sales posture: controlled-preview / invoice-only.
+
+That can support serious prospect conversations and paid controlled access, but it is not self-serve SaaS commerce. It does not prove checkout, a customer portal, automated subscription billing, or automated entitlement lifecycle.
+
+## Remaining blockers
+
+Full commercial GREEN still requires:
+
+1. claim-drift repair for `/demo` MP4 language or a real verified public MP4 URL;
+2. exact deployed `/demo-1` live-DOM receipt;
+3. first successful public-proof workflow receipt;
+4. secret/public-boundary/dependency/tenant-isolation receipts;
+5. current CI/e2e receipt;
+6. real invoice/procurement or payment receipt;
+7. onboarding/provisioning/entitlement receipt;
+8. observability, alerting, rollback, and incident-response receipts;
+9. autonomous remediation/self-healing receipts if that claim is made.
+
+## Claim-control line
+
+Allowed now:
+
+> Dominion OS has a live public demo bridge, public proof assets, public health/status endpoints, source-served receipts, executable probe scaffolding, and a controlled-preview commercial path.
+
+Not allowed now:
+
+> Direct MP4, self-serve SaaS commerce, customer portal green, production observability green, native GCP self-healing green, or full commercial all-green readiness.
+
+The bridge is open. The drawbridge is not yet a bank.

--- a/tools/verify-demo1-public-proof.mjs
+++ b/tools/verify-demo1-public-proof.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/*
+ * Dominion OS /demo-1 public proof verifier.
+ * Public-safe: fetches only public URLs declared in demo/assets/demo-1-watchlist.json
+ * and demo/assets/demo-manifest.json. Emits a JSON receipt. No secrets required.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const WATCHLIST_PATH = path.join(ROOT, 'demo/assets/demo-1-watchlist.json');
+const MANIFEST_PATH = path.join(ROOT, 'demo/assets/demo-manifest.json');
+const OUT_DIR = process.env.OUT_DIR || path.join(ROOT, 'out/demo1-public-proof');
+const STRICT = String(process.env.PROBE_STRICT || 'false').toLowerCase() === 'true';
+const TIMEOUT_MS = Number(process.env.PROBE_TIMEOUT_MS || 20000);
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+async function readJson(filePath) {
+  const raw = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function flattenUrls(watchlist) {
+  const urls = [];
+  function add(name, url, kind) {
+    if (typeof url === 'string' && url.startsWith('https://')) {
+      urls.push({ name, url, kind });
+    }
+  }
+  add('page.demo1', watchlist.page?.url, 'html');
+  for (const [key, value] of Object.entries(watchlist.runtime || {})) {
+    if (key !== 'name') add(`runtime.${key}`, value, key === 'health' || key === 'status' ? 'json' : 'html');
+  }
+  for (const [key, value] of Object.entries(watchlist.sourceServedAssets || {})) {
+    if (key === 'poster') add(`asset.${key}`, value, 'svg');
+    else if (key === 'squarespaceCode') add(`asset.${key}`, value, 'html');
+    else add(`asset.${key}`, value, 'json');
+  }
+  return urls;
+}
+
+async function fetchWithTimeout(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: { 'user-agent': 'fractal5-demo1-public-proof/1.0' }
+    });
+    const text = await res.text();
+    return {
+      ok: res.ok,
+      status: res.status,
+      contentType: res.headers.get('content-type') || '',
+      bytes: Buffer.byteLength(text),
+      body: text.slice(0, 750000)
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      contentType: '',
+      bytes: 0,
+      error: error?.message || String(error),
+      body: ''
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function includesAll(body, assertions) {
+  return assertions.map((assertion) => ({ assertion, pass: body.includes(assertion) }));
+}
+
+function contentTypePass(kind, contentType) {
+  if (kind === 'json') return contentType.includes('json') || contentType.includes('text/plain');
+  if (kind === 'svg') return contentType.includes('svg') || contentType.includes('xml') || contentType.includes('text/plain');
+  return contentType.includes('html') || contentType.includes('text/plain');
+}
+
+function deriveVerdict(results, assertionResults, claimDriftResults, manifest) {
+  const routeFailures = results.filter((r) => !r.ok || r.status !== 200);
+  const typeFailures = results.filter((r) => !contentTypePass(r.kind, r.contentType));
+  const assertionFailures = assertionResults.filter((r) => !r.pass);
+  const claimDriftFailures = claimDriftResults.filter((r) => !r.pass);
+  const directMp4 = manifest?.assets?.videoMp4 || null;
+
+  if (routeFailures.length > 0) return 'RED';
+  if (typeFailures.length > 0) return 'AMBER';
+  if (assertionFailures.length > 0) return 'AMBER';
+  if (!directMp4 && claimDriftFailures.length > 0) return 'AMBER';
+  return 'GREEN';
+}
+
+async function main() {
+  const watchlist = await readJson(WATCHLIST_PATH);
+  const manifest = await readJson(MANIFEST_PATH);
+  const urls = flattenUrls(watchlist);
+
+  const results = [];
+  for (const item of urls) {
+    const fetched = await fetchWithTimeout(item.url);
+    results.push({
+      name: item.name,
+      url: item.url,
+      kind: item.kind,
+      ok: fetched.ok,
+      status: fetched.status,
+      contentType: fetched.contentType,
+      bytes: fetched.bytes,
+      error: fetched.error || null,
+      contentTypePass: contentTypePass(item.kind, fetched.contentType)
+    });
+    item.body = fetched.body;
+  }
+
+  const demo1 = urls.find((u) => u.name === 'page.demo1')?.body || '';
+  const demoRuntime = urls.find((u) => u.name === 'runtime.demo')?.body || '';
+
+  const requiredAssertions = (watchlist.requiredAssertions || [])
+    .map((text) => String(text).replace(/^page contains\s+/i, '').replace(/^`|`$/g, ''));
+  const hardeningAssertions = watchlist.requiredHardeningAssertions || [];
+  const assertionResults = [
+    ...includesAll(demo1, requiredAssertions),
+    ...includesAll(demo1, hardeningAssertions)
+  ];
+
+  const forbiddenWhenNoMp4 = watchlist.claimDriftChecks?.forbiddenWhenManifestVideoMp4Null || [];
+  const directMp4 = manifest?.assets?.videoMp4 || null;
+  const claimDriftResults = forbiddenWhenNoMp4.map((needle) => ({
+    assertion: `runtime.demo must not contain ${needle} while assets.videoMp4 is null`,
+    pass: Boolean(directMp4) || !demoRuntime.includes(needle)
+  }));
+
+  const verdict = deriveVerdict(results, assertionResults, claimDriftResults, manifest);
+  const receipt = {
+    schema: 'f5.demo1.public-proof.receipt.v1',
+    generatedAt: nowIso(),
+    strict: STRICT,
+    verdict,
+    manifestVideoMp4: directMp4,
+    fullCommercialGreenAllowed: Boolean(manifest?.claimControl?.fullCommercialGreenAllowed),
+    summary: {
+      urlsChecked: results.length,
+      failedUrls: results.filter((r) => !r.ok || r.status !== 200).length,
+      failedAssertions: assertionResults.filter((r) => !r.pass).length,
+      claimDriftFailures: claimDriftResults.filter((r) => !r.pass).length
+    },
+    results,
+    assertionResults,
+    claimDriftResults,
+    claimControl: {
+      allowControlledPreview: verdict !== 'RED',
+      allowDirectMp4Claim: Boolean(directMp4),
+      allowFullCommercialGreen: Boolean(manifest?.claimControl?.fullCommercialGreenAllowed) && verdict === 'GREEN'
+    }
+  };
+
+  await fs.mkdir(OUT_DIR, { recursive: true });
+  const outputPath = path.join(OUT_DIR, 'latest-probe.json');
+  await fs.writeFile(outputPath, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+  console.log(JSON.stringify(receipt, null, 2));
+
+  if (STRICT && verdict !== 'GREEN') {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Purpose

Turns Issue #145 from a checklist into an executable public-proof layer for Dominion OS commercial launch readiness.

## Adds

- `tools/verify-demo1-public-proof.mjs`
- `.github/workflows/demo1-public-proof.yml`
- `demo/assets/controlled-preview-commerce-receipt.json`
- `docs/launch-readiness/2026-07-06-nhitl-unblock-execution.md`

## Updates

- `demo/assets/demo-1-watchlist.json`
  - adds hardened bridge assertions;
  - adds MP4 claim-drift checks while `assets.videoMp4` is null;
  - adds controlled-preview commerce receipt to public assets;
  - links the NHITL execution receipt.

## Claim control

This PR does **not** claim full commercial green.

It makes controlled-preview commercial use more defensible by adding a public-safe invoice-only commerce posture and executable probe receipts, while keeping the following blocked unless separate proof exists:

- direct MP4 availability;
- self-serve SaaS commerce;
- customer portal green;
- production observability green;
- native GCP self-healing green;
- full commercial all-green readiness.

## Operational effect

The GitHub Action can run manually and hourly. It fetches only public URLs and uploads `demo1-public-proof-receipt` as a JSON artifact.

No secrets. No customer data. No payment data. No private runtime artifacts.