### PR TITLE
Fix demo1 proof workflow trigger coverage

### DIFF
--- a/.github/workflows/demo1-public-proof.yml
+++ b/.github/workflows/demo1-public-proof.yml
@@ -4,15 +4,26 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '17 * * * *'
+  push:
+    branches:
+      - main
+    paths:
+      - 'demo/assets/**'
+      - 'squarespace/demo-1-final.html'
+      - 'tools/verify-demo1-public-proof.mjs'
+      - '.github/workflows/demo1-public-proof.yml'
+      - 'docs/launch-readiness/**'
   pull_request:
     paths:
       - 'demo/assets/**'
       - 'squarespace/demo-1-final.html'
       - 'tools/verify-demo1-public-proof.mjs'
       - '.github/workflows/demo1-public-proof.yml'
+      - 'docs/launch-readiness/**'
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   public-proof:


### PR DESCRIPTION
## Purpose

Repair the first `demo1-public-proof` startup failure after PR #146 by improving workflow trigger coverage.

## What changed

- Adds `push` trigger on `main` for public-proof relevant paths.
- Includes `docs/launch-readiness/**` in push and PR path filters.
- Keeps scheduled hourly and manual workflow dispatch triggers.
- Preserves public-safe permissions.

## Why

The first PR-triggered run produced `startup_failure` with no jobs, which points to scheduling/startup behavior rather than verifier-script failure. This patch ensures merged changes on `main` can produce a public-proof receipt without waiting only on the hourly cron.

No secrets. No customer data. No payment data. No private runtime artifacts.