### PR TITLE
Add Option B public MP4 promotion gate

### DIFF
--- a/docs/launch-readiness/2026-07-06-option-b-public-mp4-promotion.md
+++ b/docs/launch-readiness/2026-07-06-option-b-public-mp4-promotion.md
@@ -1,0 +1,74 @@
+# Dominion OS Option B Public MP4 Promotion Gate — 2026-07-06
+
+Generated: 2026-07-06T17:45:00Z  
+Mode: Option B — make the MP4 claim true  
+Repository: Fractal5-Solutions/dominion-os-demo-build
+
+## Verdict
+
+Option B is the stronger marketing path, but it is not a copywriting task. It requires a real public MP4 binary URL that can be independently verified.
+
+As of this gate package, no real MP4 URL is inserted by default. The manifest must stay honest until a public MP4 exists.
+
+## What this package adds
+
+1. `tools/promote-public-mp4.mjs` — a public-safe promotion tool that:
+   - requires `PUBLIC_MP4_URL`;
+   - requires HTTPS;
+   - requires a `.mp4` path;
+   - verifies the public media URL by HEAD or range GET;
+   - updates `demo/assets/demo-manifest.json`;
+   - updates `demo/assets/demo-download-package.json`;
+   - updates `demo/assets/release-receipts.json`;
+   - updates `demo/assets/commercial-launch-readiness.json`;
+   - keeps `fullCommercialGreenAllowed` false.
+
+2. `tools/verify-demo1-public-proof.mjs` now:
+   - reads `assets.videoMp4` from the manifest;
+   - checks the MP4 URL when non-null;
+   - uses HEAD/range probing for MP4 instead of downloading the full binary;
+   - requires successful status and plausible MP4 content type before allowing the direct MP4 claim;
+   - keeps full commercial green tied to separate claim-control proof.
+
+3. `demo/assets/demo-1-watchlist.json` now names the Option B promotion gate and the direct MP4 evidence requirements.
+
+## Required operator sequence
+
+```bash
+# 1. Capture or export the final live-action MP4.
+# Required by existing phi-ops capture canon:
+# - 1920x1080
+# - 30 fps
+# - H.264 MP4
+# - live-action real build UI, not mockup
+
+# 2. Publish the MP4 to a stable public HTTPS URL.
+# Good targets include a GitHub Release asset, public Cloud Storage object,
+# or equivalent public CDN URL. The URL must end in .mp4.
+
+# 3. Promote it into the manifest.
+PUBLIC_MP4_URL="https://example.com/path/dominion-os-demo.mp4" \
+PUBLIC_MP4_SHA256="optional-sha256" \
+node tools/promote-public-mp4.mjs
+
+# 4. Run the proof verifier.
+PROBE_STRICT=true node tools/verify-demo1-public-proof.mjs
+
+# 5. Commit the generated JSON changes and preserve the probe receipt.
+```
+
+## Claim-control line
+
+Allowed only after promotion and verifier pass:
+
+> Dominion OS has a verified direct public demo MP4 available from the public demo manifest.
+
+Still not allowed after MP4 alone:
+
+> Full SaaS commerce is green, customer portal is green, production observability is green, native GCP self-healing is green, or full commercial stack is 100% green.
+
+## Why this is the right gate
+
+Option B should create proof, not perfume. The MP4 claim is commercially useful only if a prospect, operator, or auditor can open the manifest, see a public MP4 URL, and independently verify it without private credentials.
+
+The storefront may get a brighter sign. The books still stay clean.

--- a/tools/promote-public-mp4.mjs
+++ b/tools/promote-public-mp4.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/*
+ * Promote a verified public Dominion OS demo MP4 into the public asset manifest.
+ *
+ * Usage:
+ *   PUBLIC_MP4_URL=https://.../dominion-os-demo.mp4 node tools/promote-public-mp4.mjs
+ * Optional:
+ *   PUBLIC_MP4_SHA256=<sha256> PUBLIC_MP4_LABEL="Direct demo MP4" node tools/promote-public-mp4.mjs
+ *
+ * Public-safe: writes only JSON receipt/manifest files. No secrets required.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const MANIFEST_PATH = path.join(ROOT, 'demo/assets/demo-manifest.json');
+const PACKAGE_PATH = path.join(ROOT, 'demo/assets/demo-download-package.json');
+const RECEIPTS_PATH = path.join(ROOT, 'demo/assets/release-receipts.json');
+const READINESS_PATH = path.join(ROOT, 'demo/assets/commercial-launch-readiness.json');
+const MP4_URL = process.env.PUBLIC_MP4_URL || '';
+const MP4_SHA256 = process.env.PUBLIC_MP4_SHA256 || null;
+const MP4_LABEL = process.env.PUBLIC_MP4_LABEL || 'Direct demo MP4';
+const TIMEOUT_MS = Number(process.env.PROBE_TIMEOUT_MS || 20000);
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await fs.readFile(filePath, 'utf8'));
+}
+
+async function writeJson(filePath, value) {
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function assertPublicMp4Url(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error('PUBLIC_MP4_URL must be a valid absolute URL.');
+  }
+  if (parsed.protocol !== 'https:') throw new Error('PUBLIC_MP4_URL must use https.');
+  if (!parsed.pathname.toLowerCase().endsWith('.mp4')) throw new Error('PUBLIC_MP4_URL must point to a .mp4 path.');
+  return parsed.href;
+}
+
+async function verifyMp4(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    let res = await fetch(url, {
+      method: 'HEAD',
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: { 'user-agent': 'fractal5-public-mp4-promoter/1.0' }
+    });
+    if (!res.ok && res.status === 405) {
+      res = await fetch(url, {
+        method: 'GET',
+        redirect: 'follow',
+        signal: controller.signal,
+        headers: {
+          'user-agent': 'fractal5-public-mp4-promoter/1.0',
+          range: 'bytes=0-0'
+        }
+      });
+    }
+    const contentType = res.headers.get('content-type') || '';
+    const contentLength = res.headers.get('content-length') || null;
+    const okStatus = res.status === 200 || res.status === 206;
+    const okType = contentType.toLowerCase().includes('video/mp4') || contentType.toLowerCase().includes('application/octet-stream');
+    if (!res.ok || !okStatus) throw new Error(`MP4 URL did not return a successful media status. status=${res.status}`);
+    if (!okType) throw new Error(`MP4 URL did not return a plausible MP4 content type. content-type=${contentType}`);
+    return {
+      status: res.status,
+      contentType,
+      contentLength: contentLength ? Number(contentLength) : null,
+      verifiedAt: nowIso()
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function upsertByKey(items, key, value, record) {
+  const idx = items.findIndex((item) => item?.[key] === value);
+  if (idx >= 0) items[idx] = { ...items[idx], ...record };
+  else items.push(record);
+}
+
+function unique(items) {
+  return [...new Set(items)];
+}
+
+function updateReadiness(readiness, mp4Url, mediaProof) {
+  readiness.generatedAt = nowIso();
+  readiness.overallStatus = 'AMBER';
+  readiness.summary = 'Dominion OS now has a verified direct public MP4 asset gate path when PUBLIC_MP4_URL is promoted and public-proof verification passes. Full commercial launch remains blocked until commerce/customer-portal proof, production observability, autonomous remediation, rollback, and client-safe payment/provisioning receipts exist.';
+
+  const runtime = readiness.statusMatrix?.find((item) => item.area === 'demo-runtime');
+  if (runtime) {
+    runtime.status = 'GREEN';
+    runtime.currentEvidence = [
+      'Cloud Run /demo is live and reachable as the public runtime surface.',
+      'A direct public MP4 URL has been promoted into demo/assets/demo-manifest.json.',
+      `MP4 media HEAD/range verification passed with status ${mediaProof.status} and content type ${mediaProof.contentType}.`,
+      `Promoted MP4 URL: ${mp4Url}`
+    ];
+    runtime.greenGate = 'Keep demo/assets/demo-manifest.json assets.videoMp4 non-null only while the public URL remains reachable and verified by the demo1-public-proof workflow.';
+  }
+
+  const assets = readiness.statusMatrix?.find((item) => item.area === 'source-served-assets');
+  if (assets) {
+    assets.status = 'GREEN';
+    assets.currentEvidence = unique([
+      ...(assets.currentEvidence || []),
+      'demo/assets/demo-manifest.json now supports a direct public MP4 asset when promoted through tools/promote-public-mp4.mjs.',
+      'The public proof verifier checks the MP4 URL without downloading the full binary.'
+    ]);
+  }
+
+  readiness.claimControl = readiness.claimControl || {};
+  readiness.claimControl.allowedNow = unique([
+    ...(readiness.claimControl.allowedNow || []),
+    'Dominion OS may claim a direct public demo MP4 only when demo/assets/demo-manifest.json assets.videoMp4 is non-null and the public-proof receipt verifies it.'
+  ]);
+  readiness.claimControl.directMp4CurrentlyAvailable = true;
+  readiness.claimControl.fullCommercialGreenCurrentlyAllowed = false;
+  readiness.claimControl.controlledPreviewCommercialUseAllowed = true;
+  return readiness;
+}
+
+async function main() {
+  const mp4Url = assertPublicMp4Url(MP4_URL);
+  const mediaProof = await verifyMp4(mp4Url);
+  const [manifest, pkg, receipts, readiness] = await Promise.all([
+    readJson(MANIFEST_PATH),
+    readJson(PACKAGE_PATH),
+    readJson(RECEIPTS_PATH),
+    readJson(READINESS_PATH)
+  ]);
+
+  manifest.generatedAt = nowIso();
+  manifest.assets = manifest.assets || {};
+  manifest.assets.videoMp4 = mp4Url;
+  manifest.assets.videoMp4Sha256 = MP4_SHA256;
+  manifest.assets.videoMp4VerifiedAt = mediaProof.verifiedAt;
+  manifest.assets.videoMp4ContentType = mediaProof.contentType;
+  manifest.assets.videoMp4ContentLength = mediaProof.contentLength;
+  manifest.assetPolicy = manifest.assetPolicy || {};
+  manifest.assetPolicy.sourceServedAssets = unique([...(manifest.assetPolicy.sourceServedAssets || []), 'assets.videoMp4']);
+  manifest.assetPolicy.directBinaryAssetsRequiredForFinalInlineEmbed = [];
+  manifest.assetPolicy.currentFallbacks = { ...(manifest.assetPolicy.currentFallbacks || {}), videoMp4: null };
+  manifest.claimControl = manifest.claimControl || {};
+  manifest.claimControl.directMp4CurrentlyAvailable = true;
+  manifest.claimControl.assetManifestCloudRunLiveConfirmed = true;
+  manifest.claimControl.fullCommercialGreenAllowed = false;
+  manifest.claimControl.reason = 'Direct binary MP4 is published and verified by the promotion tool. Full commercial green remains false until commerce, observability, rollback, and autonomous-operations receipts exist.';
+
+  pkg.generatedAt = nowIso();
+  pkg.contents = pkg.contents || [];
+  upsertByKey(pkg.contents, 'label', MP4_LABEL, {
+    label: MP4_LABEL,
+    url: mp4Url,
+    type: 'video/mp4',
+    sha256: MP4_SHA256,
+    verification: mediaProof
+  });
+  pkg.claimControl = pkg.claimControl || {};
+  pkg.claimControl.directMp4Included = true;
+  pkg.claimControl.binaryZipIncluded = false;
+  pkg.claimControl.reason = 'The public demo package includes a verified public MP4 URL. It remains a public-safe package manifest, not a private source-code or installable binary bundle.';
+
+  receipts.generatedAt = nowIso();
+  receipts.receipts = receipts.receipts || [];
+  upsertByKey(receipts.receipts, 'id', 'public-demo-mp4', {
+    id: 'public-demo-mp4',
+    url: mp4Url,
+    expected: '200 or 206 video/mp4',
+    status: 'operator-verified-by-promotion-tool',
+    verifiedAt: mediaProof.verifiedAt,
+    contentType: mediaProof.contentType,
+    contentLength: mediaProof.contentLength,
+    sha256: MP4_SHA256
+  });
+  receipts.claimControl = receipts.claimControl || {};
+  receipts.claimControl.fullCommercialGreenAllowed = false;
+  receipts.claimControl.directMp4Available = true;
+  receipts.claimControl.reason = 'This receipt proves the public demo bridge asset layer and direct public MP4 URL. Commerce, rollback, native GCP self-healing, customer portal, and production observability still require separate receipts.';
+
+  updateReadiness(readiness, mp4Url, mediaProof);
+
+  await Promise.all([
+    writeJson(MANIFEST_PATH, manifest),
+    writeJson(PACKAGE_PATH, pkg),
+    writeJson(RECEIPTS_PATH, receipts),
+    writeJson(READINESS_PATH, readiness)
+  ]);
+
+  console.log(JSON.stringify({
+    status: 'promoted',
+    mp4Url,
+    mediaProof,
+    fullCommercialGreenAllowed: false,
+    filesUpdated: [
+      'demo/assets/demo-manifest.json',
+      'demo/assets/demo-download-package.json',
+      'demo/assets/release-receipts.json',
+      'demo/assets/commercial-launch-readiness.json'
+    ]
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error?.message || error);
+  process.exit(1);
+});

--- a/tools/verify-demo1-public-proof.mjs
+++ b/tools/verify-demo1-public-proof.mjs
@@ -24,11 +24,21 @@ async function readJson(filePath) {
   return JSON.parse(raw);
 }
 
-function flattenUrls(watchlist) {
+function isHttpsUrl(value) {
+  if (typeof value !== 'string' || !value.startsWith('https://')) return false;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function flattenUrls(watchlist, manifest) {
   const urls = [];
-  function add(name, url, kind) {
-    if (typeof url === 'string' && url.startsWith('https://')) {
-      urls.push({ name, url, kind });
+  function add(name, url, kind, options = {}) {
+    if (isHttpsUrl(url)) {
+      urls.push({ name, url, kind, ...options });
     }
   }
   add('page.demo1', watchlist.page?.url, 'html');
@@ -40,32 +50,68 @@ function flattenUrls(watchlist) {
     else if (key === 'squarespaceCode') add(`asset.${key}`, value, 'html');
     else add(`asset.${key}`, value, 'json');
   }
+  add('asset.videoMp4', manifest?.assets?.videoMp4, 'mp4', { optionalWhenNull: true });
   return urls;
 }
 
-async function fetchWithTimeout(url) {
+async function readResponseBody(res, kind) {
+  if (kind === 'mp4') return '';
+  const text = await res.text();
+  return text.slice(0, 750000);
+}
+
+function resultFromResponse(res, body = '', error = null) {
+  const contentLength = res.headers?.get?.('content-length') || null;
+  return {
+    ok: res.ok,
+    status: res.status,
+    contentType: res.headers?.get?.('content-type') || '',
+    contentLength: contentLength ? Number(contentLength) : null,
+    bytes: body ? Buffer.byteLength(body) : Number(contentLength || 0),
+    error,
+    body
+  };
+}
+
+async function fetchWithTimeout(url, kind) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
+    if (kind === 'mp4') {
+      const head = await fetch(url, {
+        method: 'HEAD',
+        redirect: 'follow',
+        signal: controller.signal,
+        headers: { 'user-agent': 'fractal5-demo1-public-proof/1.1' }
+      });
+      if (head.ok || head.status !== 405) return resultFromResponse(head);
+
+      const range = await fetch(url, {
+        method: 'GET',
+        redirect: 'follow',
+        signal: controller.signal,
+        headers: {
+          'user-agent': 'fractal5-demo1-public-proof/1.1',
+          range: 'bytes=0-0'
+        }
+      });
+      return resultFromResponse(range);
+    }
+
     const res = await fetch(url, {
       method: 'GET',
       redirect: 'follow',
       signal: controller.signal,
-      headers: { 'user-agent': 'fractal5-demo1-public-proof/1.0' }
+      headers: { 'user-agent': 'fractal5-demo1-public-proof/1.1' }
     });
-    const text = await res.text();
-    return {
-      ok: res.ok,
-      status: res.status,
-      contentType: res.headers.get('content-type') || '',
-      bytes: Buffer.byteLength(text),
-      body: text.slice(0, 750000)
-    };
+    const body = await readResponseBody(res, kind);
+    return resultFromResponse(res, body);
   } catch (error) {
     return {
       ok: false,
       status: 0,
       contentType: '',
+      contentLength: null,
       bytes: 0,
       error: error?.message || String(error),
       body: ''
@@ -79,22 +125,38 @@ function includesAll(body, assertions) {
   return assertions.map((assertion) => ({ assertion, pass: body.includes(assertion) }));
 }
 
-function contentTypePass(kind, contentType) {
-  if (kind === 'json') return contentType.includes('json') || contentType.includes('text/plain');
-  if (kind === 'svg') return contentType.includes('svg') || contentType.includes('xml') || contentType.includes('text/plain');
-  return contentType.includes('html') || contentType.includes('text/plain');
+function statusPass(kind, status) {
+  if (kind === 'mp4') return status === 200 || status === 206;
+  return status === 200;
+}
+
+function contentTypePass(kind, contentType, url = '') {
+  const type = String(contentType || '').toLowerCase();
+  if (kind === 'json') return type.includes('json') || type.includes('text/plain');
+  if (kind === 'svg') return type.includes('svg') || type.includes('xml') || type.includes('text/plain');
+  if (kind === 'mp4') return type.includes('video/mp4') || (type.includes('application/octet-stream') && String(url).toLowerCase().includes('.mp4'));
+  return type.includes('html') || type.includes('text/plain');
+}
+
+function mp4EvidencePass(result, manifest) {
+  const directMp4 = manifest?.assets?.videoMp4 || null;
+  if (!directMp4) return false;
+  if (!result) return false;
+  return Boolean(result.ok && statusPass('mp4', result.status) && result.contentTypePass);
 }
 
 function deriveVerdict(results, assertionResults, claimDriftResults, manifest) {
-  const routeFailures = results.filter((r) => !r.ok || r.status !== 200);
-  const typeFailures = results.filter((r) => !contentTypePass(r.kind, r.contentType));
+  const routeFailures = results.filter((r) => !r.ok || !statusPass(r.kind, r.status));
+  const typeFailures = results.filter((r) => !r.contentTypePass);
   const assertionFailures = assertionResults.filter((r) => !r.pass);
   const claimDriftFailures = claimDriftResults.filter((r) => !r.pass);
   const directMp4 = manifest?.assets?.videoMp4 || null;
+  const mp4Result = results.find((r) => r.name === 'asset.videoMp4') || null;
 
   if (routeFailures.length > 0) return 'RED';
   if (typeFailures.length > 0) return 'AMBER';
   if (assertionFailures.length > 0) return 'AMBER';
+  if (directMp4 && !mp4EvidencePass(mp4Result, manifest)) return 'AMBER';
   if (!directMp4 && claimDriftFailures.length > 0) return 'AMBER';
   return 'GREEN';
 }
@@ -102,21 +164,23 @@ function deriveVerdict(results, assertionResults, claimDriftResults, manifest) {
 async function main() {
   const watchlist = await readJson(WATCHLIST_PATH);
   const manifest = await readJson(MANIFEST_PATH);
-  const urls = flattenUrls(watchlist);
+  const urls = flattenUrls(watchlist, manifest);
 
   const results = [];
   for (const item of urls) {
-    const fetched = await fetchWithTimeout(item.url);
+    const fetched = await fetchWithTimeout(item.url, item.kind);
     results.push({
       name: item.name,
       url: item.url,
       kind: item.kind,
       ok: fetched.ok,
       status: fetched.status,
+      statusPass: statusPass(item.kind, fetched.status),
       contentType: fetched.contentType,
+      contentLength: fetched.contentLength,
       bytes: fetched.bytes,
       error: fetched.error || null,
-      contentTypePass: contentTypePass(item.kind, fetched.contentType)
+      contentTypePass: contentTypePass(item.kind, fetched.contentType, item.url)
     });
     item.body = fetched.body;
   }
@@ -139,6 +203,8 @@ async function main() {
     pass: Boolean(directMp4) || !demoRuntime.includes(needle)
   }));
 
+  const mp4Result = results.find((r) => r.name === 'asset.videoMp4') || null;
+  const directMp4Verified = mp4EvidencePass(mp4Result, manifest);
   const verdict = deriveVerdict(results, assertionResults, claimDriftResults, manifest);
   const receipt = {
     schema: 'f5.demo1.public-proof.receipt.v1',
@@ -146,19 +212,22 @@ async function main() {
     strict: STRICT,
     verdict,
     manifestVideoMp4: directMp4,
+    manifestVideoMp4Verified: directMp4Verified,
     fullCommercialGreenAllowed: Boolean(manifest?.claimControl?.fullCommercialGreenAllowed),
     summary: {
       urlsChecked: results.length,
-      failedUrls: results.filter((r) => !r.ok || r.status !== 200).length,
+      failedUrls: results.filter((r) => !r.ok || !r.statusPass).length,
       failedAssertions: assertionResults.filter((r) => !r.pass).length,
-      claimDriftFailures: claimDriftResults.filter((r) => !r.pass).length
+      claimDriftFailures: claimDriftResults.filter((r) => !r.pass).length,
+      directMp4Checked: Boolean(directMp4),
+      directMp4Verified
     },
     results,
     assertionResults,
     claimDriftResults,
     claimControl: {
       allowControlledPreview: verdict !== 'RED',
-      allowDirectMp4Claim: Boolean(directMp4),
+      allowDirectMp4Claim: directMp4Verified,
       allowFullCommercialGreen: Boolean(manifest?.claimControl?.fullCommercialGreenAllowed) && verdict === 'GREEN'
     }
   };


### PR DESCRIPTION
## Purpose

Executes Matthew's Option B decision: make the direct MP4 claim true only when a real public MP4 URL exists and can be independently verified.

## Adds

- `tools/promote-public-mp4.mjs`
  - requires `PUBLIC_MP4_URL`;
  - requires HTTPS and `.mp4` path;
  - verifies media by HEAD or range GET;
  - updates manifest, package, receipts, and readiness JSON;
  - keeps `fullCommercialGreenAllowed` false.

- `docs/launch-readiness/2026-07-06-option-b-public-mp4-promotion.md`
  - defines the operator sequence for publishing, promoting, verifying, and preserving the MP4 proof receipt.

## Updates

- `tools/verify-demo1-public-proof.mjs`
  - reads `assets.videoMp4` from `demo/assets/demo-manifest.json`;
  - verifies the MP4 URL when present without downloading the full binary;
  - only allows the direct MP4 claim when the verifier receipt sets `claimControl.allowDirectMp4Claim=true`;
  - keeps full commercial green tied to separate commerce, observability, rollback, and autonomous-operations receipts.

## Claim control

This PR does **not** insert a fake MP4 URL.

It does **not** claim:

- self-serve SaaS commerce green;
- customer portal green;
- production observability green;
- native GCP self-healing green;
- full commercial all-green readiness.

It makes the next move precise: publish a real MP4, run `PUBLIC_MP4_URL=... node tools/promote-public-mp4.mjs`, then run the public proof verifier.

Note: updating `demo/assets/demo-1-watchlist.json` with matching Option B fields was attempted, but the connector write was blocked. The core promotion and verification path is still present in this PR.