### PR TITLE
Repair public MP4 claim control and proof receipts

### DIFF
--- a/.github/workflows/demo1-public-proof.yml
+++ b/.github/workflows/demo1-public-proof.yml
@@ -13,9 +13,22 @@ on:
       - 'tools/verify-demo1-public-proof.mjs'
       - '.github/workflows/demo1-public-proof.yml'
       - 'docs/launch-readiness/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'demo/assets/**'
+      - 'squarespace/demo-1-final.html'
+      - 'tools/verify-demo1-public-proof.mjs'
+      - '.github/workflows/demo1-public-proof.yml'
+      - 'docs/launch-readiness/**'
 
 permissions:
   contents: read
+
+concurrency:
+  group: demo1-public-proof-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   public-proof:
@@ -44,3 +57,4 @@ jobs:
           name: demo1-public-proof-receipt
           path: out/demo1-public-proof/latest-probe.json
           if-no-files-found: error
+          retention-days: 30

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,7 +41,7 @@ steps:
       - --port
       - '8080'
       - --set-env-vars
-      - SERVICE_NAME=$_SERVICE_NAME,PROJECT_ID=$PROJECT_ID,REGION=$_REGION
+      - SERVICE_NAME=$_SERVICE_NAME,PROJECT_ID=$PROJECT_ID,REGION=$_REGION,APP_VERSION=$_APP_VERSION,RELEASE_SHA=$COMMIT_SHA,RELEASE_REPO=dominion-os-demo-build,SOURCE_OF_TRUTH_REPO=dominion-os-demo-build,SOURCE_OF_TRUTH_SHA=$COMMIT_SHA,IMAGE_REF=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_NAME}:${_TAG}
       - --quiet
 
 substitutions:
@@ -51,6 +51,7 @@ substitutions:
   _DOCKERFILE: Dockerfile.production
   _BUILD_CONTEXT: .
   _TAG: latest
+  _APP_VERSION: 2026-07-16-claim-control-cutover
 
 images:
   - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_NAME}:${_TAG}

--- a/demo/assets/demo-1-watchlist.json
+++ b/demo/assets/demo-1-watchlist.json
@@ -1,10 +1,10 @@
 {
-  "schema": "f5.demo1.watchlist.v1",
-  "generatedAt": "2026-07-06T00:45:00Z",
+  "schema": "f5.demo1.watchlist.v2",
+  "generatedAt": "2026-07-15T13:30:00Z",
   "page": {
     "name": "Fractal5 /demo-1",
     "url": "https://www.fractal5solutions.com/demo-1",
-    "role": "public Squarespace bridge for Dominion OS 1.0 live demo"
+    "role": "public Squarespace bridge for Dominion OS live demo"
   },
   "runtime": {
     "name": "Dominion OS Cloud Run demo",
@@ -32,7 +32,8 @@
   "expectedStatus": {
     "html": 200,
     "json": 200,
-    "svg": 200
+    "svg": 200,
+    "mp4": [200, 206]
   },
   "requiredAssertions": [
     "Dominion OS, live on the cloud.",
@@ -56,6 +57,7 @@
     "ALLOWED_FRACTAL5_URLS"
   ],
   "claimDriftChecks": {
+    "caseInsensitive": true,
     "forbiddenWhenManifestVideoMp4Null": [
       "Actual demo MP4 integrated",
       "Open web MP4",
@@ -65,6 +67,21 @@
     ],
     "manifestVideoMp4Path": "assets.videoMp4",
     "allowedFallbackWhenNull": "sections.watchVideo"
+  },
+  "directMp4EvidenceRequirements": {
+    "requiredBeforeClaim": true,
+    "urlProtocol": "https",
+    "urlPathSuffix": ".mp4",
+    "allowedHttpStatus": [200, 206],
+    "allowedContentTypes": ["video/mp4", "application/octet-stream for an .mp4 URL"],
+    "receiptField": "claimControl.allowDirectMp4Claim",
+    "rule": "A non-null manifest URL alone is not proof. The current public-proof receipt must verify the media response."
+  },
+  "workflowReceipt": {
+    "workflow": "demo1-public-proof",
+    "artifact": "demo1-public-proof-receipt",
+    "receiptPath": "out/demo1-public-proof/latest-probe.json",
+    "requiredForGateClosure": true
   },
   "commercialGreenGates": [
     "deployed /demo-1 live-DOM verification receipt",
@@ -85,6 +102,7 @@
     "fullCommerceGreenCurrentlyAllowed": false,
     "fullCommercialGreenCurrentlyAllowed": false,
     "controlledPreviewCommercialUseAllowed": true,
-    "reason": "The public bridge and source-served assets support controlled preview sharing. Direct MP4, full self-serve commerce, native GCP self-healing, production observability, and production customer portal proof require separate receipts."
+    "runtimeCopyRepairRequired": true,
+    "reason": "The public bridge and source-served assets support controlled preview sharing. The deployed Cloud Run /demo copy must not claim an integrated direct MP4 while the manifest videoMp4 value is null. Full self-serve commerce, native GCP self-healing, production observability, and production customer-portal proof require separate receipts."
   }
 }

--- a/deploy_demo.sh
+++ b/deploy_demo.sh
@@ -8,13 +8,17 @@ AR_REPO="${AR_REPO:-dominion-demo-repo}"
 DOCKERFILE="${DOCKERFILE:-Dockerfile.production}"
 BUILD_CONTEXT="${BUILD_CONTEXT:-.}"
 TAG="${TAG:-latest}"
+APP_VERSION="${APP_VERSION:-2026-07-16-claim-control-cutover}"
 DEMO_HOST="${DEMO_HOST:-https://www.fractal5solutions.com/demo}"
 
-echo "== Fractal5 Demo Deploy =="
-echo "Project:  ${PROJECT_ID}"
-echo "Region:   ${REGION}"
-echo "Service:   ${SERVICE_NAME}"
-echo "Image:    ${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/${SERVICE_NAME}:${TAG}"
+IMAGE_REF="${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/${SERVICE_NAME}:${TAG}"
+
+printf '%s\n' "== Fractal5 Demo Deploy =="
+printf 'Project:  %s\n' "${PROJECT_ID}"
+printf 'Region:   %s\n' "${REGION}"
+printf 'Service:  %s\n' "${SERVICE_NAME}"
+printf 'Image:    %s\n' "${IMAGE_REF}"
+printf 'Version:  %s\n' "${APP_VERSION}"
 
 if ! gcloud auth list --filter=status:ACTIVE --format='value(account)' | grep -q '@'; then
   echo "ERROR: no active gcloud identity found. Run: gcloud auth login"
@@ -50,15 +54,17 @@ gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
 gcloud builds submit "${BUILD_CONTEXT}" \
   --project="${PROJECT_ID}" \
   --config=cloudbuild.yaml \
-  --substitutions="_SERVICE_NAME=${SERVICE_NAME},_REGION=${REGION},_AR_REPO=${AR_REPO},_DOCKERFILE=${DOCKERFILE},_BUILD_CONTEXT=${BUILD_CONTEXT},_TAG=${TAG}"
+  --substitutions="_SERVICE_NAME=${SERVICE_NAME},_REGION=${REGION},_AR_REPO=${AR_REPO},_DOCKERFILE=${DOCKERFILE},_BUILD_CONTEXT=${BUILD_CONTEXT},_TAG=${TAG},_APP_VERSION=${APP_VERSION}"
 
 SERVICE_URL="$(gcloud run services describe "${SERVICE_NAME}" --project="${PROJECT_ID}" --region="${REGION}" --format='value(status.url)')"
 
-echo
-echo "Deployment complete."
-echo "Service URL: ${SERVICE_URL}"
-echo "Demo URL:    ${DEMO_HOST}"
-echo
-echo "Smoke checks:"
-echo "  curl -I ${DEMO_HOST}"
-echo "  curl -s ${SERVICE_URL}/healthz"
+printf '\nDeployment submitted.\n'
+printf 'Service URL: %s\n' "${SERVICE_URL}"
+printf 'Demo URL:    %s\n' "${DEMO_HOST}"
+printf '\nSmoke checks:\n'
+printf '  curl -I %s\n' "${DEMO_HOST}"
+printf '  curl -s %s/health | jq .\n' "${SERVICE_URL}"
+printf '  curl -s https://www.fractal5solutions.com/status | jq .\n'
+printf '\nClaim-drift check:\n'
+printf '  The live /demo page must not contain: All-green release evidence, Actual demo MP4 integrated, Open web MP4, Open master MP4.\n'
+printf '  Only set all-green after demo1-public-proof and every #649 gate passes.\n'

--- a/docs/launch-readiness/2026-07-16-demo-claim-drift-cutover-receipt.md
+++ b/docs/launch-readiness/2026-07-16-demo-claim-drift-cutover-receipt.md
@@ -1,0 +1,50 @@
+# Demo claim-drift cutover receipt — 2026-07-16
+
+## Verdict
+
+`BLOCKED_PENDING_DEPLOYMENT`
+
+The checked-in `main` demo shell is softer than the live Cloud Run `/demo` surface. The live runtime still displays direct-MP4/all-green language that is not supported by the current manifest.
+
+## Current public evidence
+
+- Live Cloud Run `/demo` text observed: `All-green release evidence`, `Actual demo MP4 integrated`, `Checking integrated MP4 variants`, `Open web MP4`, and `Open master MP4`.
+- Current public manifest evidence: `assets.videoMp4` is `null`.
+- Current public manifest evidence: `claimControl.fullCommercialGreenAllowed` is `false`.
+- Current readiness matrix evidence: commercial launch remains `AMBER` and direct MP4/full commercial green remain explicitly disallowed without separate receipts.
+
+## Source inspection
+
+`demo/index.html` on the repository mainline does not contain the observed direct-MP4/all-green language. The current mainline demo shell presents a gated operator experience and hydratable live-state cards instead of an embedded MP4 claim.
+
+Therefore the likely repair is not another source-copy edit in `demo/index.html`; it is a deployment cutover to a current safe artifact, or identification/removal of the older generated runtime artifact currently served by Cloud Run.
+
+## Required cutover
+
+Run the approved deployment path from an authorized workstation or CI/CD surface with GCP credentials:
+
+1. Build from the current `Fractal5-Solutions/dominion-os-demo-build` source after claim-control PR review.
+2. Deploy the `dominion-demo` Cloud Run service from the safe artifact.
+3. Verify `https://demo-reduwyf2ra-uc.a.run.app/demo` no longer contains:
+   - `All-green release evidence`
+   - `Actual demo MP4 integrated`
+   - `Open web MP4`
+   - `Open master MP4`
+4. Verify `/health` and `/status` remain HTTP 200 public-safe JSON.
+5. Re-run `demo1-public-proof` and attach the no-secret receipt.
+6. Keep `assets.videoMp4: null` and `fullCommercialGreenAllowed: false` until a real HTTPS `.mp4` asset passes HEAD/range proof and all commercial gates pass.
+
+## Do not claim
+
+- direct public MP4 available;
+- full commercial green;
+- customer portal green;
+- self-serve SaaS commerce green;
+- native GCP self-healing green;
+- production observability green.
+
+## Safe interim public language
+
+Use only controlled-preview language until the cutover receipt exists:
+
+> Dominion OS has a public-safe Cloud Run sandbox, health/status receipts, source-served demo assets, and a controlled-access buyer path. Direct MP4 playback, full self-serve commerce, customer portal readiness, production observability, and autonomous remediation are not claimed without separate receipts.

--- a/docs/launch-readiness/receipts/2026-07-15-chief-of-staff-claim-control-repair.json
+++ b/docs/launch-readiness/receipts/2026-07-15-chief-of-staff-claim-control-repair.json
@@ -1,0 +1,54 @@
+{
+  "schema": "f5.dominion.claim-control-repair.v1",
+  "generatedAt": "2026-07-15T13:35:00Z",
+  "repository": "Fractal5-Solutions/dominion-os-demo-build",
+  "branch": "chief-of-staff/claim-control-repair-20260715",
+  "overallStatus": "AMBER_CONTROLLED_PREVIEW_ONLY",
+  "diagnosis": {
+    "canonicalDemo1Bridge": "claim-safe and hardened in repository source",
+    "manifestVideoMp4": null,
+    "manifestDirectMp4ClaimAllowed": false,
+    "deployedRuntimeDemo": "publicly reachable but previously observed with direct-MP4-complete copy while the manifest remained null",
+    "rootCause": [
+      "deployed Cloud Run runtime copy drifted beyond the source-served manifest evidence",
+      "the public-proof verifier previously allowed a direct MP4 claim from any non-null manifest URL without verifying the media response"
+    ]
+  },
+  "repairs": [
+    {
+      "path": "tools/verify-demo1-public-proof.mjs",
+      "status": "completed_on_branch",
+      "effect": "Verifies a public MP4 by HEAD or range GET, requires HTTP 200 or 206 and a plausible media content type, performs case-insensitive claim-drift checks, and only permits the claim when the media verifies."
+    },
+    {
+      "path": "demo/assets/demo-1-watchlist.json",
+      "status": "completed_on_branch",
+      "effect": "Adds explicit direct-MP4 evidence requirements, artifact receipt requirements, case-insensitive drift policy, and a runtime-copy-repair flag."
+    },
+    {
+      "path": ".github/workflows/demo1-public-proof.yml",
+      "status": "completed_on_branch",
+      "effect": "Runs the strict public proof on relevant pull requests as well as main, serializes duplicate runs, and retains the public-safe receipt artifact for 30 days."
+    }
+  ],
+  "remainingAction": {
+    "gate": "Gate 1 public claim drift",
+    "status": "deployment_required",
+    "action": "Redeploy the Cloud Run /demo page with direct-MP4-complete wording and MP4 buttons removed or disabled until demo/assets/demo-manifest.json contains a real public MP4 URL and a current verifier receipt proves it.",
+    "reason": "The runtime page implementation containing the observed wording was not found in this repository, so repository-only changes cannot honestly prove the deployed copy is repaired."
+  },
+  "claimControl": {
+    "directMp4ClaimAllowed": false,
+    "fullCommercialGreenAllowed": false,
+    "controlledPreviewCommercialUseAllowed": true,
+    "commerceCustomerPortalGreen": false,
+    "productionObservabilityGreen": false,
+    "autonomousOperationsGreen": false
+  },
+  "security": {
+    "secretsIncluded": false,
+    "customerDataIncluded": false,
+    "paymentDataIncluded": false,
+    "privateRuntimeArtifactsIncluded": false
+  }
+}

--- a/tools/verify-demo1-public-proof.mjs
+++ b/tools/verify-demo1-public-proof.mjs
@@ -20,16 +20,22 @@ function nowIso() {
 }
 
 async function readJson(filePath) {
-  const raw = await fs.readFile(filePath, 'utf8');
-  return JSON.parse(raw);
+  return JSON.parse(await fs.readFile(filePath, 'utf8'));
 }
 
-function flattenUrls(watchlist) {
+function isHttpsUrl(value) {
+  if (typeof value !== 'string' || !value.startsWith('https://')) return false;
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function flattenUrls(watchlist, manifest) {
   const urls = [];
   function add(name, url, kind) {
-    if (typeof url === 'string' && url.startsWith('https://')) {
-      urls.push({ name, url, kind });
-    }
+    if (isHttpsUrl(url)) urls.push({ name, url, kind });
   }
   add('page.demo1', watchlist.page?.url, 'html');
   for (const [key, value] of Object.entries(watchlist.runtime || {})) {
@@ -40,36 +46,58 @@ function flattenUrls(watchlist) {
     else if (key === 'squarespaceCode') add(`asset.${key}`, value, 'html');
     else add(`asset.${key}`, value, 'json');
   }
+  add('asset.videoMp4', manifest?.assets?.videoMp4, 'mp4');
   return urls;
 }
 
-async function fetchWithTimeout(url) {
+function responseResult(res, body = '', error = null) {
+  const contentLength = res?.headers?.get?.('content-length') || null;
+  return {
+    ok: Boolean(res?.ok),
+    status: Number(res?.status || 0),
+    contentType: res?.headers?.get?.('content-type') || '',
+    contentLength: contentLength ? Number(contentLength) : null,
+    bytes: body ? Buffer.byteLength(body) : Number(contentLength || 0),
+    error,
+    body
+  };
+}
+
+async function fetchWithTimeout(url, kind) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
+    if (kind === 'mp4') {
+      let res = await fetch(url, {
+        method: 'HEAD',
+        redirect: 'follow',
+        signal: controller.signal,
+        headers: { 'user-agent': 'fractal5-demo1-public-proof/1.2' }
+      });
+      if (res.status === 405) {
+        res = await fetch(url, {
+          method: 'GET',
+          redirect: 'follow',
+          signal: controller.signal,
+          headers: {
+            'user-agent': 'fractal5-demo1-public-proof/1.2',
+            range: 'bytes=0-0'
+          }
+        });
+      }
+      return responseResult(res);
+    }
+
     const res = await fetch(url, {
       method: 'GET',
       redirect: 'follow',
       signal: controller.signal,
-      headers: { 'user-agent': 'fractal5-demo1-public-proof/1.0' }
+      headers: { 'user-agent': 'fractal5-demo1-public-proof/1.2' }
     });
-    const text = await res.text();
-    return {
-      ok: res.ok,
-      status: res.status,
-      contentType: res.headers.get('content-type') || '',
-      bytes: Buffer.byteLength(text),
-      body: text.slice(0, 750000)
-    };
+    const body = (await res.text()).slice(0, 750000);
+    return responseResult(res, body);
   } catch (error) {
-    return {
-      ok: false,
-      status: 0,
-      contentType: '',
-      bytes: 0,
-      error: error?.message || String(error),
-      body: ''
-    };
+    return responseResult(null, '', error?.message || String(error));
   } finally {
     clearTimeout(timeout);
   }
@@ -79,98 +107,111 @@ function includesAll(body, assertions) {
   return assertions.map((assertion) => ({ assertion, pass: body.includes(assertion) }));
 }
 
-function contentTypePass(kind, contentType) {
-  if (kind === 'json') return contentType.includes('json') || contentType.includes('text/plain');
-  if (kind === 'svg') return contentType.includes('svg') || contentType.includes('xml') || contentType.includes('text/plain');
-  return contentType.includes('html') || contentType.includes('text/plain');
+function statusPass(kind, status) {
+  if (kind === 'mp4') return status === 200 || status === 206;
+  return status === 200;
 }
 
-function deriveVerdict(results, assertionResults, claimDriftResults, manifest) {
-  const routeFailures = results.filter((r) => !r.ok || r.status !== 200);
-  const typeFailures = results.filter((r) => !contentTypePass(r.kind, r.contentType));
-  const assertionFailures = assertionResults.filter((r) => !r.pass);
-  const claimDriftFailures = claimDriftResults.filter((r) => !r.pass);
-  const directMp4 = manifest?.assets?.videoMp4 || null;
+function contentTypePass(kind, contentType, url = '') {
+  const type = String(contentType || '').toLowerCase();
+  if (kind === 'json') return type.includes('json') || type.includes('text/plain');
+  if (kind === 'svg') return type.includes('svg') || type.includes('xml') || type.includes('text/plain');
+  if (kind === 'mp4') {
+    return type.includes('video/mp4') || (type.includes('application/octet-stream') && String(url).toLowerCase().includes('.mp4'));
+  }
+  return type.includes('html') || type.includes('text/plain');
+}
 
-  if (routeFailures.length > 0) return 'RED';
-  if (typeFailures.length > 0) return 'AMBER';
-  if (assertionFailures.length > 0) return 'AMBER';
-  if (!directMp4 && claimDriftFailures.length > 0) return 'AMBER';
+function mp4EvidencePass(result, manifest) {
+  const directMp4 = manifest?.assets?.videoMp4 || null;
+  return Boolean(directMp4 && result?.ok && result?.statusPass && result?.contentTypePass);
+}
+
+function deriveVerdict(results, assertionResults, claimDriftResults, directMp4Verified) {
+  if (results.some((r) => !r.ok || !r.statusPass)) return 'RED';
+  if (results.some((r) => !r.contentTypePass)) return 'AMBER';
+  if (assertionResults.some((r) => !r.pass)) return 'AMBER';
+  if (claimDriftResults.some((r) => !r.pass)) return 'AMBER';
+  if (results.some((r) => r.kind === 'mp4') && !directMp4Verified) return 'AMBER';
   return 'GREEN';
 }
 
 async function main() {
   const watchlist = await readJson(WATCHLIST_PATH);
   const manifest = await readJson(MANIFEST_PATH);
-  const urls = flattenUrls(watchlist);
+  const urls = flattenUrls(watchlist, manifest);
 
   const results = [];
   for (const item of urls) {
-    const fetched = await fetchWithTimeout(item.url);
+    const fetched = await fetchWithTimeout(item.url, item.kind);
     results.push({
       name: item.name,
       url: item.url,
       kind: item.kind,
       ok: fetched.ok,
       status: fetched.status,
+      statusPass: statusPass(item.kind, fetched.status),
       contentType: fetched.contentType,
+      contentLength: fetched.contentLength,
       bytes: fetched.bytes,
       error: fetched.error || null,
-      contentTypePass: contentTypePass(item.kind, fetched.contentType)
+      contentTypePass: contentTypePass(item.kind, fetched.contentType, item.url),
+      body: fetched.body
     });
-    item.body = fetched.body;
   }
 
-  const demo1 = urls.find((u) => u.name === 'page.demo1')?.body || '';
-  const demoRuntime = urls.find((u) => u.name === 'runtime.demo')?.body || '';
-
+  const demo1 = results.find((r) => r.name === 'page.demo1')?.body || '';
+  const demoRuntime = results.find((r) => r.name === 'runtime.demo')?.body || '';
   const requiredAssertions = (watchlist.requiredAssertions || [])
     .map((text) => String(text).replace(/^page contains\s+/i, '').replace(/^`|`$/g, ''));
-  const hardeningAssertions = watchlist.requiredHardeningAssertions || [];
   const assertionResults = [
     ...includesAll(demo1, requiredAssertions),
-    ...includesAll(demo1, hardeningAssertions)
+    ...includesAll(demo1, watchlist.requiredHardeningAssertions || [])
   ];
 
-  const forbiddenWhenNoMp4 = watchlist.claimDriftChecks?.forbiddenWhenManifestVideoMp4Null || [];
   const directMp4 = manifest?.assets?.videoMp4 || null;
+  const runtimeLower = demoRuntime.toLowerCase();
+  const forbiddenWhenNoMp4 = watchlist.claimDriftChecks?.forbiddenWhenManifestVideoMp4Null || [];
   const claimDriftResults = forbiddenWhenNoMp4.map((needle) => ({
     assertion: `runtime.demo must not contain ${needle} while assets.videoMp4 is null`,
-    pass: Boolean(directMp4) || !demoRuntime.includes(needle)
+    pass: Boolean(directMp4) || !runtimeLower.includes(String(needle).toLowerCase())
   }));
 
-  const verdict = deriveVerdict(results, assertionResults, claimDriftResults, manifest);
+  const mp4Result = results.find((r) => r.name === 'asset.videoMp4') || null;
+  const directMp4Verified = mp4EvidencePass(mp4Result, manifest);
+  const verdict = deriveVerdict(results, assertionResults, claimDriftResults, directMp4Verified);
+
   const receipt = {
-    schema: 'f5.demo1.public-proof.receipt.v1',
+    schema: 'f5.demo1.public-proof.receipt.v2',
     generatedAt: nowIso(),
     strict: STRICT,
     verdict,
     manifestVideoMp4: directMp4,
+    manifestVideoMp4Verified: directMp4Verified,
     fullCommercialGreenAllowed: Boolean(manifest?.claimControl?.fullCommercialGreenAllowed),
     summary: {
       urlsChecked: results.length,
-      failedUrls: results.filter((r) => !r.ok || r.status !== 200).length,
+      failedUrls: results.filter((r) => !r.ok || !r.statusPass).length,
       failedAssertions: assertionResults.filter((r) => !r.pass).length,
-      claimDriftFailures: claimDriftResults.filter((r) => !r.pass).length
+      claimDriftFailures: claimDriftResults.filter((r) => !r.pass).length,
+      directMp4Checked: Boolean(directMp4),
+      directMp4Verified
     },
-    results,
+    results: results.map(({ body, ...result }) => result),
     assertionResults,
     claimDriftResults,
     claimControl: {
       allowControlledPreview: verdict !== 'RED',
-      allowDirectMp4Claim: Boolean(directMp4),
+      allowDirectMp4Claim: directMp4Verified,
       allowFullCommercialGreen: Boolean(manifest?.claimControl?.fullCommercialGreenAllowed) && verdict === 'GREEN'
     }
   };
 
   await fs.mkdir(OUT_DIR, { recursive: true });
-  const outputPath = path.join(OUT_DIR, 'latest-probe.json');
-  await fs.writeFile(outputPath, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+  await fs.writeFile(path.join(OUT_DIR, 'latest-probe.json'), `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
   console.log(JSON.stringify(receipt, null, 2));
 
-  if (STRICT && verdict !== 'GREEN') {
-    process.exitCode = 1;
-  }
+  if (STRICT && verdict !== 'GREEN') process.exitCode = 1;
 }
 
 main().catch((error) => {

--- a/tools/verify-demo1-public-proof.mjs
+++ b/tools/verify-demo1-public-proof.mjs
@@ -14,6 +14,8 @@ const MANIFEST_PATH = path.join(ROOT, 'demo/assets/demo-manifest.json');
 const OUT_DIR = process.env.OUT_DIR || path.join(ROOT, 'out/demo1-public-proof');
 const STRICT = String(process.env.PROBE_STRICT || 'false').toLowerCase() === 'true';
 const TIMEOUT_MS = Number(process.env.PROBE_TIMEOUT_MS || 20000);
+const GITHUB_REPOSITORY = String(process.env.GITHUB_REPOSITORY || '');
+const GITHUB_SHA = String(process.env.GITHUB_SHA || '');
 
 function nowIso() {
   return new Date().toISOString();
@@ -32,21 +34,52 @@ function isHttpsUrl(value) {
   }
 }
 
+function urlPathEndsWith(value, suffix) {
+  try {
+    return new URL(value).pathname.toLowerCase().endsWith(String(suffix).toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+function pinRawGithubUrlToCurrentSha(url) {
+  if (!GITHUB_REPOSITORY || !GITHUB_SHA || !isHttpsUrl(url)) return url;
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== 'raw.githubusercontent.com') return url;
+    const parts = parsed.pathname.split('/').filter(Boolean);
+    if (parts.length < 4) return url;
+    const [owner, repo, _ref, ...fileParts] = parts;
+    const candidateRepo = `${owner}/${repo}`.toLowerCase();
+    if (candidateRepo !== GITHUB_REPOSITORY.toLowerCase()) return url;
+    return `https://raw.githubusercontent.com/${owner}/${repo}/${GITHUB_SHA}/${fileParts.join('/')}`;
+  } catch {
+    return url;
+  }
+}
+
 function flattenUrls(watchlist, manifest) {
   const urls = [];
-  function add(name, url, kind) {
-    if (isHttpsUrl(url)) urls.push({ name, url, kind });
+  function add(name, url, kind, options = {}) {
+    if (isHttpsUrl(url)) {
+      urls.push({ name, url, kind, validUrl: true });
+      return;
+    }
+    if (options.requiredWhenPresent && url) {
+      urls.push({ name, url: String(url), kind, validUrl: false });
+    }
   }
   add('page.demo1', watchlist.page?.url, 'html');
   for (const [key, value] of Object.entries(watchlist.runtime || {})) {
     if (key !== 'name') add(`runtime.${key}`, value, key === 'health' || key === 'status' ? 'json' : 'html');
   }
   for (const [key, value] of Object.entries(watchlist.sourceServedAssets || {})) {
-    if (key === 'poster') add(`asset.${key}`, value, 'svg');
-    else if (key === 'squarespaceCode') add(`asset.${key}`, value, 'html');
-    else add(`asset.${key}`, value, 'json');
+    const sourceServedUrl = pinRawGithubUrlToCurrentSha(value);
+    if (key === 'poster') add(`asset.${key}`, sourceServedUrl, 'svg');
+    else if (key === 'squarespaceCode') add(`asset.${key}`, sourceServedUrl, 'html');
+    else add(`asset.${key}`, sourceServedUrl, 'json');
   }
-  add('asset.videoMp4', manifest?.assets?.videoMp4, 'mp4');
+  add('asset.videoMp4', manifest?.assets?.videoMp4, 'mp4', { requiredWhenPresent: true });
   return urls;
 }
 
@@ -117,14 +150,14 @@ function contentTypePass(kind, contentType, url = '') {
   if (kind === 'json') return type.includes('json') || type.includes('text/plain');
   if (kind === 'svg') return type.includes('svg') || type.includes('xml') || type.includes('text/plain');
   if (kind === 'mp4') {
-    return type.includes('video/mp4') || (type.includes('application/octet-stream') && String(url).toLowerCase().includes('.mp4'));
+    return type.includes('video/mp4') || (type.includes('application/octet-stream') && urlPathEndsWith(url, '.mp4'));
   }
   return type.includes('html') || type.includes('text/plain');
 }
 
 function mp4EvidencePass(result, manifest) {
   const directMp4 = manifest?.assets?.videoMp4 || null;
-  return Boolean(directMp4 && result?.ok && result?.statusPass && result?.contentTypePass);
+  return Boolean(directMp4 && result?.validUrl !== false && result?.ok && result?.statusPass && result?.contentTypePass);
 }
 
 function deriveVerdict(results, assertionResults, claimDriftResults, directMp4Verified) {
@@ -143,11 +176,29 @@ async function main() {
 
   const results = [];
   for (const item of urls) {
+    if (item.validUrl === false) {
+      results.push({
+        name: item.name,
+        url: item.url,
+        kind: item.kind,
+        validUrl: false,
+        ok: false,
+        status: 0,
+        statusPass: false,
+        contentType: '',
+        contentLength: null,
+        bytes: 0,
+        error: 'invalid or non-HTTPS URL',
+        contentTypePass: false
+      });
+      continue;
+    }
     const fetched = await fetchWithTimeout(item.url, item.kind);
     results.push({
       name: item.name,
       url: item.url,
       kind: item.kind,
+      validUrl: item.validUrl,
       ok: fetched.ok,
       status: fetched.status,
       statusPass: statusPass(item.kind, fetched.status),


### PR DESCRIPTION
## Purpose

Repairs the Dominion OS commercial-readiness claim-control defect identified in the Chief of Staff audit.

## Diagnosis

- `squarespace/demo-1-final.html` and `demo/assets/demo-manifest.json` remain claim-safe.
- The manifest still has `assets.videoMp4: null`.
- The deployed Cloud Run `/demo` surface was observed presenting direct-MP4-complete wording and MP4 links without a current verifier receipt.
- The existing verifier treated a non-null manifest URL as sufficient claim permission without independently verifying the media response.

## Repairs

- Hardens `tools/verify-demo1-public-proof.mjs`:
  - MP4 HEAD/range verification;
  - HTTP 200/206 and plausible content-type requirement;
  - case-insensitive runtime claim-drift detection;
  - direct-MP4 claim allowed only after verified media evidence;
  - receipt schema v2 with response bodies excluded.
- Strengthens `demo/assets/demo-1-watchlist.json` with explicit MP4 evidence and artifact requirements.
- Runs `demo1-public-proof` on relevant pull requests, adds concurrency control, and retains artifacts for 30 days.
- Adds a public-safe Chief of Staff repair receipt.

## Remaining deployment action

This PR cannot by itself change the already deployed Cloud Run page because the runtime source containing the observed wording was not found in this repository. The deployment owner must remove or disable direct-MP4-complete copy/buttons until a real public MP4 is published and verified.

## Claim control

This PR does **not** claim:

- a direct public MP4 is currently available;
- self-serve commerce or customer portal is green;
- production observability or autonomous operations are green;
- full commercial green.

Controlled-preview AMBER remains the honest ceiling until the deployed runtime copy is repaired and the remaining Issue #145 receipts exist.

No secrets. No customer data. No payment data. No private runtime artifacts.