### PR TITLE
Add chief-of-staff commercial readiness closeout

### DIFF
--- a/docs/launch-readiness/CHIEF_OF_STAFF_CLOSEOUT_2026-07-15.md
+++ b/docs/launch-readiness/CHIEF_OF_STAFF_CLOSEOUT_2026-07-15.md
@@ -1,0 +1,69 @@
+# Chief-of-Staff Commercial Readiness Closeout — 2026-07-15
+
+Status: AMBER / CONTROLLED PREVIEW ONLY
+
+This closeout records the durable Dominion OS commercial launch readiness state so the verification thread can be retired unless new evidence changes the gates.
+
+## Canonical surfaces
+
+- Canonical website bridge: `https://www.fractal5solutions.com/demo-1`
+- Live public Cloud Run demo: `https://demo-reduwyf2ra-uc.a.run.app/demo`
+- Health JSON: `https://demo-reduwyf2ra-uc.a.run.app/health`
+- Status JSON: `https://demo-reduwyf2ra-uc.a.run.app/status`
+- Source-of-truth repo: `Fractal5-Solutions/dominion-os-demo-build`
+- Old Squarespace `/demo` route: ignored / retired for this launch-readiness packet
+
+## Completed in this closeout
+
+- Verified `/demo-1` is live and functioning as the canonical public bridge.
+- Verified `/demo-1` publicly exposes live demo, recording/proof path, health, status, manifest, sample data, package, receipts, readiness, watchlist, and controlled-access routing.
+- Verified the source bridge package contains `data-version="2026-06-08-hardened"`, required CTAs, `noopener noreferrer`, strict referrer policy, hidden poster fallback, and URL allowlist hardening.
+- Verified source-served assets remain public-safe and claim-controlled.
+- Verified PR #127 was already merged.
+- Merged PR #153, preserving the 2026-07-10 AMBER commercial-readiness audit receipt on `main`.
+
+## Current status matrix
+
+| Area | Status | Closeout note |
+|---|---:|---|
+| Demo runtime | AMBER | Runtime is reachable, but direct MP4 language remains inconsistent with `demo-manifest.json`, where `assets.videoMp4` is still `null`. |
+| Hardened website bridge | GREEN | `/demo-1` is canonical, live, proof-oriented, and source package is hardened. |
+| Source-served assets | GREEN | Manifest, poster, sample data, package, receipts, readiness, and watchlist are public-safe assets. |
+| Security | AMBER | Public boundaries and hardening metadata exist; full production security receipt is still required for commercial green. |
+| Build/test | AMBER | Watchlist and readiness receipts exist; current full CI/e2e/security pass receipt is still required. |
+| Cloud health | AMBER | Health/status endpoints respond, but generated timestamps are stale relative to this closeout and need freshness proof before green. |
+| Commerce/customer portal | RED | No public proof of live checkout, customer portal, subscription billing, entitlement lifecycle, support, refund, or privacy receipts. |
+| Observability | AMBER | Health/status exist; uptime monitor, alert routing, SLO, incident, trace/metric retention, and rollback receipts remain missing. |
+| Autonomous operations | AMBER | PHI/Ops evidence exists, but native production self-healing/autonomous remediation is not proven for commercial green. |
+
+## Claim control
+
+Allowed now:
+
+- Dominion OS has a live public Google Cloud demo surface.
+- Dominion OS has a canonical Fractal5 `/demo-1` public website bridge for controlled prospect sharing.
+- Dominion OS has source-served public demo assets and public proof surfaces.
+- Controlled commercial preview / governed discovery / invoice-first sales conversations are allowed.
+
+Not allowed yet:
+
+- Do not claim direct public MP4 unless a real public MP4 URL is published and verified.
+- Do not claim full self-serve SaaS commerce is green.
+- Do not claim customer portal green.
+- Do not claim production observability green.
+- Do not claim native GCP self-healing or autonomous remediation green.
+- Do not claim full commercial launch green.
+
+## Permanent closeout rule
+
+Do not reopen this verification thread for routine status anxiety. Reopen only when one of these changes:
+
+1. a real direct public MP4 is published and the manifest is updated,
+2. the live demo copy is corrected to remove false MP4-complete language,
+3. fresh Cloud Run health/status receipts are generated,
+4. production security/build/e2e receipts are produced,
+5. commerce or invoice-only customer onboarding receipts are documented,
+6. observability, rollback, and incident-response receipts exist,
+7. autonomous remediation/self-healing evidence exists and is safe to claim.
+
+Until then, the truthful commercial posture is: controlled preview, not full commercial green.


### PR DESCRIPTION
Adds a durable closeout receipt for the Dominion OS commercial launch readiness thread.

Verdict preserved: AMBER / controlled preview only.

This records:

- `/demo-1` as the canonical website bridge
- live Cloud Run demo/health/status surfaces
- source-served asset proof
- PR #127 already merged
- PR #153 merged during closeout
- remaining blockers for full commercial green
- claim-control rules so this thread does not need to be reopened for routine anxiety

No secrets, customer data, payment data, or private operational endpoints are included.