### PR TITLE
Rebase claim control and runtime freshness on current main

### DIFF
--- a/.github/workflows/demo1-public-proof.yml
+++ b/.github/workflows/demo1-public-proof.yml
@@ -13,9 +13,22 @@ on:
       - 'tools/verify-demo1-public-proof.mjs'
       - '.github/workflows/demo1-public-proof.yml'
       - 'docs/launch-readiness/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'demo/assets/**'
+      - 'squarespace/demo-1-final.html'
+      - 'tools/verify-demo1-public-proof.mjs'
+      - '.github/workflows/demo1-public-proof.yml'
+      - 'docs/launch-readiness/**'
 
 permissions:
   contents: read
+
+concurrency:
+  group: demo1-public-proof-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   public-proof:
@@ -34,6 +47,7 @@ jobs:
       - name: Run public proof verifier
         env:
           PROBE_STRICT: 'true'
+          MAX_RECEIPT_AGE_SECONDS: '900'
           OUT_DIR: out/demo1-public-proof
         run: node tools/verify-demo1-public-proof.mjs
 
@@ -44,3 +58,4 @@ jobs:
           name: demo1-public-proof-receipt
           path: out/demo1-public-proof/latest-probe.json
           if-no-files-found: error
+          retention-days: 30

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -21,6 +21,7 @@ RUN pip install --no-cache-dir --user --upgrade pip setuptools wheel && \
 # Build a strict public runtime payload and strip plain Python source.
 RUN mkdir -p /runtime/scripts/telemetry /runtime/demo /runtime/store /runtime/products
 COPY command_core.py /runtime/
+COPY commercial_runtime.py /runtime/
 COPY demo /runtime/demo
 COPY store /runtime/store
 COPY products /runtime/products
@@ -28,7 +29,8 @@ COPY scripts/telemetry/config_project1.txt /runtime/scripts/telemetry/config_pro
 COPY scripts/telemetry/config_project2.txt /runtime/scripts/telemetry/config_project2.txt
 COPY scripts/telemetry/services_project1.txt /runtime/scripts/telemetry/services_project1.txt
 COPY scripts/telemetry/services_project2.txt /runtime/scripts/telemetry/services_project2.txt
-RUN python -m compileall -b /runtime/command_core.py && rm /runtime/command_core.py
+RUN python -m compileall -b /runtime/command_core.py /runtime/commercial_runtime.py && \
+    rm /runtime/command_core.py /runtime/commercial_runtime.py
 
 # Stage 2: Production runtime
 FROM python:3.12-slim AS production
@@ -85,4 +87,4 @@ CMD exec gunicorn --bind :${PORT:-8080} \
     --access-logfile - \
     --error-logfile - \
     --log-file - \
-    "command_core:app"
+    "commercial_runtime:app"

--- a/commercial_runtime.py
+++ b/commercial_runtime.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Public receipt hardening wrapper for the Dominion OS demo runtime."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+
+from flask import request
+
+from command_core import app
+
+PUBLIC_RECEIPT_PATHS = frozenset({
+    "/health",
+    "/healthz",
+    "/ready",
+    "/status",
+    "/_ah/health",
+})
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def runtime_revision(payload: dict) -> str:
+    return (
+        os.getenv("K_REVISION")
+        or os.getenv("REVISION")
+        or str(payload.get("revision") or "local")
+    )
+
+
+@app.after_request
+def add_public_receipt_metadata(response):
+    if request.path not in PUBLIC_RECEIPT_PATHS or not response.is_json:
+        return response
+
+    payload = response.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return response
+
+    generated_at = utc_now_iso()
+    payload["generatedAt"] = generated_at
+    payload["timestamp"] = generated_at
+    payload["revision"] = runtime_revision(payload)
+    payload["configuration"] = os.getenv("K_CONFIGURATION", "")
+    payload["releaseCandidateSha"] = (
+        os.getenv("RELEASE_SHA") or str(payload.get("release_sha") or "")
+    )
+    payload["receiptFreshnessSeconds"] = 0
+
+    response.set_data(json.dumps(payload, ensure_ascii=True, separators=(",", ":")))
+    response.headers["Content-Type"] = "application/json; charset=utf-8"
+    response.headers["Cache-Control"] = "no-store, max-age=0, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+    return response
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", "8080"))
+    app.run(host="0.0.0.0", port=port, debug=False)

--- a/demo/assets/demo-1-watchlist.json
+++ b/demo/assets/demo-1-watchlist.json
@@ -1,6 +1,6 @@
 {
-  "schema": "f5.demo1.watchlist.v1",
-  "generatedAt": "2026-07-15T13:35:00Z",
+  "schema": "f5.demo1.watchlist.v2",
+  "generatedAt": "2026-07-16T23:50:00Z",
   "page": {
     "name": "Fractal5 /demo-1",
     "url": "https://www.fractal5solutions.com/demo-1",
@@ -35,7 +35,8 @@
   "expectedStatus": {
     "html": 200,
     "json": 200,
-    "svg": 200
+    "svg": 200,
+    "mp4": [200, 206]
   },
   "assertionScopes": {
     "requiredAssertions": "live deployed Squarespace /demo-1 page text and links",
@@ -66,6 +67,7 @@
     "ALLOWED_FRACTAL5_URLS"
   ],
   "claimDriftChecks": {
+    "caseInsensitive": true,
     "forbiddenWhenManifestVideoMp4Null": [
       "Actual demo MP4 integrated",
       "Open web MP4",
@@ -75,6 +77,28 @@
     ],
     "manifestVideoMp4Path": "assets.videoMp4",
     "allowedFallbackWhenNull": "sections.watchVideo"
+  },
+  "directMp4EvidenceRequirements": {
+    "requiredBeforeClaim": true,
+    "urlProtocol": "https",
+    "urlPathSuffix": ".mp4",
+    "allowedHttpStatus": [200, 206],
+    "allowedContentTypes": ["video/mp4", "application/octet-stream for an .mp4 URL"],
+    "receiptField": "claimControl.allowDirectMp4Claim",
+    "rule": "A non-null manifest URL alone is not proof. The current public-proof receipt must verify the media response."
+  },
+  "runtimeFreshnessRequirements": {
+    "routes": ["runtime.health", "runtime.status"],
+    "timestampFields": ["generatedAt", "timestamp", "generated_at"],
+    "maximumAgeSeconds": 900,
+    "rule": "Health and status receipts must be current and non-regressing; stale runtime payloads cannot support cloud-health green."
+  },
+  "workflowReceipt": {
+    "workflow": "demo1-public-proof",
+    "artifact": "demo1-public-proof-receipt",
+    "receiptPath": "out/demo1-public-proof/latest-probe.json",
+    "retentionDays": 30,
+    "requiredForGateClosure": true
   },
   "publicBridgeGates": [
     "live /demo-1 deployed page exposes the current public proof bridge assertions",
@@ -103,6 +127,7 @@
     "fullCommerceGreenCurrentlyAllowed": false,
     "fullCommercialGreenCurrentlyAllowed": false,
     "controlledPreviewCommercialUseAllowed": true,
-    "reason": "The current public bridge and source-served assets support controlled preview sharing. Direct MP4, full self-serve commerce, native GCP self-healing, production observability, and production customer portal proof require separate receipts."
+    "runtimeCopyRepairRequired": true,
+    "reason": "The current public bridge and source-served assets support controlled preview sharing. Direct MP4, full self-serve commerce, native GCP self-healing, production observability, and production customer portal proof require separate receipts. Runtime health and status must also remain fresh."
   }
 }

--- a/tests/test_commercial_runtime.py
+++ b/tests/test_commercial_runtime.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timezone
+
+from commercial_runtime import app
+
+
+def assert_fresh_receipt(response):
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "no-store, max-age=0, must-revalidate"
+    assert response.headers["Pragma"] == "no-cache"
+
+    payload = response.get_json()
+    assert payload["generatedAt"] == payload["timestamp"]
+    generated = datetime.fromisoformat(payload["generatedAt"].replace("Z", "+00:00"))
+    age = (datetime.now(timezone.utc) - generated).total_seconds()
+    assert 0 <= age < 5
+    assert payload["receiptFreshnessSeconds"] == 0
+    assert "revision" in payload
+    assert "releaseCandidateSha" in payload
+
+
+def test_health_receipt_is_fresh_and_uncached(monkeypatch):
+    monkeypatch.setenv("K_REVISION", "test-revision")
+    monkeypatch.setenv("RELEASE_SHA", "abc123")
+    with app.test_client() as client:
+        response = client.get("/health")
+    assert_fresh_receipt(response)
+    payload = response.get_json()
+    assert payload["revision"] == "test-revision"
+    assert payload["releaseCandidateSha"] == "abc123"
+
+
+def test_status_receipt_is_fresh_and_uncached(monkeypatch):
+    monkeypatch.setenv("K_REVISION", "test-revision")
+    with app.test_client() as client:
+        response = client.get("/status")
+    assert_fresh_receipt(response)

--- a/tools/verify-demo1-public-proof.mjs
+++ b/tools/verify-demo1-public-proof.mjs
@@ -1,10 +1,5 @@
 #!/usr/bin/env node
-/*
- * Dominion OS /demo-1 public proof verifier.
- * Public-safe: fetches only public URLs declared in demo/assets/demo-1-watchlist.json
- * and demo/assets/demo-manifest.json. Emits a JSON receipt. No secrets required.
- */
-
+/* Public-safe Dominion OS /demo-1 verifier. No secrets or response bodies in receipts. */
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
@@ -14,125 +9,150 @@ const MANIFEST_PATH = path.join(ROOT, 'demo/assets/demo-manifest.json');
 const OUT_DIR = process.env.OUT_DIR || path.join(ROOT, 'out/demo1-public-proof');
 const STRICT = String(process.env.PROBE_STRICT || 'false').toLowerCase() === 'true';
 const TIMEOUT_MS = Number(process.env.PROBE_TIMEOUT_MS || 20000);
+const MAX_RECEIPT_AGE_SECONDS = Number(process.env.MAX_RECEIPT_AGE_SECONDS || 900);
+const GITHUB_REPOSITORY = String(process.env.GITHUB_REPOSITORY || '');
+const GITHUB_SHA = String(process.env.GITHUB_SHA || '');
 
-function nowIso() {
-  return new Date().toISOString();
+const nowIso = () => new Date().toISOString();
+const readJson = async (filePath) => JSON.parse(await fs.readFile(filePath, 'utf8'));
+
+function isHttpsUrl(value) {
+  if (typeof value !== 'string' || !value.startsWith('https://')) return false;
+  try { return new URL(value).protocol === 'https:'; } catch { return false; }
 }
 
-async function readJson(filePath) {
-  const raw = await fs.readFile(filePath, 'utf8');
-  return JSON.parse(raw);
+function urlPathEndsWith(value, suffix) {
+  try { return new URL(value).pathname.toLowerCase().endsWith(String(suffix).toLowerCase()); }
+  catch { return false; }
 }
 
-function flattenUrls(watchlist) {
+function pinRawGithubUrlToCurrentSha(url) {
+  if (!GITHUB_REPOSITORY || !GITHUB_SHA || !isHttpsUrl(url)) return url;
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== 'raw.githubusercontent.com') return url;
+    const parts = parsed.pathname.split('/').filter(Boolean);
+    if (parts.length < 4) return url;
+    const [owner, repo, _ref, ...fileParts] = parts;
+    if (`${owner}/${repo}`.toLowerCase() !== GITHUB_REPOSITORY.toLowerCase()) return url;
+    return `https://raw.githubusercontent.com/${owner}/${repo}/${GITHUB_SHA}/${fileParts.join('/')}`;
+  } catch { return url; }
+}
+
+function flattenUrls(watchlist, manifest) {
   const urls = [];
-  function add(name, url, kind) {
-    if (typeof url === 'string' && url.startsWith('https://')) {
-      urls.push({ name, url, kind });
-    }
-  }
+  const add = (name, url, kind, requiredWhenPresent = false) => {
+    if (isHttpsUrl(url)) urls.push({ name, url, kind, validUrl: true });
+    else if (requiredWhenPresent && url) urls.push({ name, url: String(url), kind, validUrl: false });
+  };
   add('page.demo1', watchlist.page?.url, 'html');
   for (const [key, value] of Object.entries(watchlist.runtime || {})) {
     if (key !== 'name') add(`runtime.${key}`, value, key === 'health' || key === 'status' ? 'json' : 'html');
   }
   for (const [key, value] of Object.entries(watchlist.sourceServedAssets || {})) {
-    if (key === 'poster') add(`asset.${key}`, value, 'svg');
-    else if (key === 'squarespaceCode') add(`asset.${key}`, value, 'html');
-    else add(`asset.${key}`, value, 'json');
+    const url = pinRawGithubUrlToCurrentSha(value);
+    if (key === 'poster') add(`asset.${key}`, url, 'svg');
+    else if (key === 'squarespaceCode') add(`asset.${key}`, url, 'html');
+    else add(`asset.${key}`, url, 'json');
   }
+  add('asset.videoMp4', manifest?.assets?.videoMp4, 'mp4', true);
   return urls;
 }
 
-async function fetchWithTimeout(url) {
+function responseResult(res, body = '', error = null) {
+  const contentLength = res?.headers?.get?.('content-length') || null;
+  return {
+    ok: Boolean(res?.ok), status: Number(res?.status || 0),
+    contentType: res?.headers?.get?.('content-type') || '',
+    cacheControl: res?.headers?.get?.('cache-control') || '',
+    contentLength: contentLength ? Number(contentLength) : null,
+    bytes: body ? Buffer.byteLength(body) : Number(contentLength || 0), error, body
+  };
+}
+
+async function fetchWithTimeout(url, kind) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
-    const res = await fetch(url, {
-      method: 'GET',
-      redirect: 'follow',
-      signal: controller.signal,
-      headers: { 'user-agent': 'fractal5-demo1-public-proof/1.1' }
-    });
-    const text = await res.text();
-    return {
-      ok: res.ok,
-      status: res.status,
-      contentType: res.headers.get('content-type') || '',
-      bytes: Buffer.byteLength(text),
-      body: text.slice(0, 750000)
-    };
-  } catch (error) {
-    return {
-      ok: false,
-      status: 0,
-      contentType: '',
-      bytes: 0,
-      error: error?.message || String(error),
-      body: ''
-    };
-  } finally {
-    clearTimeout(timeout);
-  }
+    if (kind === 'mp4') {
+      let res = await fetch(url, { method: 'HEAD', redirect: 'follow', signal: controller.signal,
+        headers: { 'user-agent': 'fractal5-demo1-public-proof/2.0' } });
+      if (res.status === 405) {
+        res = await fetch(url, { method: 'GET', redirect: 'follow', signal: controller.signal,
+          headers: { 'user-agent': 'fractal5-demo1-public-proof/2.0', range: 'bytes=0-0' } });
+      }
+      return responseResult(res);
+    }
+    const res = await fetch(url, { method: 'GET', redirect: 'follow', signal: controller.signal,
+      headers: { 'user-agent': 'fractal5-demo1-public-proof/2.0', 'cache-control': 'no-cache' } });
+    return responseResult(res, (await res.text()).slice(0, 750000));
+  } catch (error) { return responseResult(null, '', error?.message || String(error)); }
+  finally { clearTimeout(timeout); }
 }
 
-function normalizeAssertion(assertion) {
-  return String(assertion).replace(/^page contains\s+/i, '').replace(/^`|`$/g, '');
+function contentTypePass(kind, contentType, url = '') {
+  const type = String(contentType || '').toLowerCase();
+  if (kind === 'json') return type.includes('json') || type.includes('text/plain');
+  if (kind === 'svg') return type.includes('svg') || type.includes('xml') || type.includes('text/plain');
+  if (kind === 'mp4') return type.includes('video/mp4') || (type.includes('application/octet-stream') && urlPathEndsWith(url, '.mp4'));
+  return type.includes('html') || type.includes('text/plain');
 }
 
-function includesAll(body, assertions, target) {
-  return assertions.map((assertion) => ({
-    assertion,
-    target,
-    pass: body.includes(assertion)
-  }));
+const statusPass = (kind, status) => kind === 'mp4' ? status === 200 || status === 206 : status === 200;
+const normalizeAssertion = (value) => String(value).replace(/^page contains\s+/i, '').replace(/^`|`$/g, '');
+const includesAll = (body, assertions, target) => assertions.map((assertion) => ({ assertion, target, pass: body.includes(assertion) }));
+
+function parseJsonBody(result) {
+  try { return JSON.parse(result?.body || ''); } catch { return null; }
 }
 
-function contentTypePass(kind, contentType) {
-  if (kind === 'json') return contentType.includes('json') || contentType.includes('text/plain');
-  if (kind === 'svg') return contentType.includes('svg') || contentType.includes('xml') || contentType.includes('text/plain');
-  return contentType.includes('html') || contentType.includes('text/plain');
+function freshnessCheck(result) {
+  const payload = parseJsonBody(result);
+  const raw = payload?.generatedAt || payload?.timestamp || payload?.generated_at || null;
+  const millis = raw ? Date.parse(raw) : NaN;
+  const ageSeconds = Number.isFinite(millis) ? Math.max(0, Math.floor((Date.now() - millis) / 1000)) : null;
+  return {
+    target: result?.name || 'unknown', timestamp: raw, ageSeconds,
+    maxAgeSeconds: MAX_RECEIPT_AGE_SECONDS,
+    cacheControl: result?.cacheControl || '',
+    pass: ageSeconds !== null && ageSeconds <= MAX_RECEIPT_AGE_SECONDS
+  };
 }
 
-function deriveVerdict(results, assertionResults, claimDriftResults, manifest) {
-  const routeFailures = results.filter((r) => !r.ok || r.status !== 200);
-  const typeFailures = results.filter((r) => !contentTypePass(r.kind, r.contentType));
-  const assertionFailures = assertionResults.filter((r) => !r.pass);
-  const claimDriftFailures = claimDriftResults.filter((r) => !r.pass);
-  const directMp4 = manifest?.assets?.videoMp4 || null;
-
-  if (routeFailures.length > 0) return 'RED';
-  if (typeFailures.length > 0) return 'AMBER';
-  if (assertionFailures.length > 0) return 'AMBER';
-  if (!directMp4 && claimDriftFailures.length > 0) return 'AMBER';
+function deriveVerdict(results, assertionResults, claimDriftResults, freshnessResults, directMp4Verified) {
+  if (results.some((r) => !r.ok || !r.statusPass)) return 'RED';
+  if (results.some((r) => !r.contentTypePass)) return 'AMBER';
+  if (assertionResults.some((r) => !r.pass)) return 'AMBER';
+  if (claimDriftResults.some((r) => !r.pass)) return 'AMBER';
+  if (freshnessResults.some((r) => !r.pass)) return 'AMBER';
+  if (results.some((r) => r.kind === 'mp4') && !directMp4Verified) return 'AMBER';
   return 'GREEN';
 }
 
 async function main() {
   const watchlist = await readJson(WATCHLIST_PATH);
   const manifest = await readJson(MANIFEST_PATH);
-  const urls = flattenUrls(watchlist);
-
+  const urls = flattenUrls(watchlist, manifest);
   const results = [];
+
   for (const item of urls) {
-    const fetched = await fetchWithTimeout(item.url);
-    results.push({
-      name: item.name,
-      url: item.url,
-      kind: item.kind,
-      ok: fetched.ok,
-      status: fetched.status,
-      contentType: fetched.contentType,
-      bytes: fetched.bytes,
-      error: fetched.error || null,
-      contentTypePass: contentTypePass(item.kind, fetched.contentType)
-    });
-    item.body = fetched.body;
+    if (item.validUrl === false) {
+      results.push({ name: item.name, url: item.url, kind: item.kind, validUrl: false, ok: false,
+        status: 0, statusPass: false, contentType: '', cacheControl: '', contentLength: null,
+        bytes: 0, error: 'invalid or non-HTTPS URL', contentTypePass: false, body: '' });
+      continue;
+    }
+    const fetched = await fetchWithTimeout(item.url, item.kind);
+    results.push({ name: item.name, url: item.url, kind: item.kind, validUrl: item.validUrl,
+      ok: fetched.ok, status: fetched.status, statusPass: statusPass(item.kind, fetched.status),
+      contentType: fetched.contentType, cacheControl: fetched.cacheControl,
+      contentLength: fetched.contentLength, bytes: fetched.bytes, error: fetched.error || null,
+      contentTypePass: contentTypePass(item.kind, fetched.contentType, item.url), body: fetched.body });
   }
 
-  const demo1 = urls.find((u) => u.name === 'page.demo1')?.body || '';
-  const demoRuntime = urls.find((u) => u.name === 'runtime.demo')?.body || '';
-  const hardenedSource = urls.find((u) => u.name === 'asset.squarespaceCode')?.body || '';
-
+  const demo1 = results.find((r) => r.name === 'page.demo1')?.body || '';
+  const demoRuntime = results.find((r) => r.name === 'runtime.demo')?.body || '';
+  const hardenedSource = results.find((r) => r.name === 'asset.squarespaceCode')?.body || '';
   const requiredAssertions = (watchlist.requiredAssertions || []).map(normalizeAssertion);
   const hardeningAssertions = (watchlist.requiredHardeningAssertions || []).map(normalizeAssertion);
   const assertionResults = [
@@ -140,56 +160,45 @@ async function main() {
     ...includesAll(hardenedSource, hardeningAssertions, 'source:squarespace/demo-1-final.html')
   ];
 
-  const forbiddenWhenNoMp4 = watchlist.claimDriftChecks?.forbiddenWhenManifestVideoMp4Null || [];
   const directMp4 = manifest?.assets?.videoMp4 || null;
-  const claimDriftResults = forbiddenWhenNoMp4.map((needle) => ({
-    assertion: `runtime.demo must not contain ${needle} while assets.videoMp4 is null`,
-    target: 'runtime:/demo',
-    pass: Boolean(directMp4) || !demoRuntime.includes(needle)
+  const runtimeLower = demoRuntime.toLowerCase();
+  const claimDriftResults = (watchlist.claimDriftChecks?.forbiddenWhenManifestVideoMp4Null || []).map((needle) => ({
+    assertion: `runtime.demo must not contain ${needle} while assets.videoMp4 is null`, target: 'runtime:/demo',
+    pass: Boolean(directMp4) || !runtimeLower.includes(String(needle).toLowerCase())
   }));
+  const mp4Result = results.find((r) => r.name === 'asset.videoMp4') || null;
+  const directMp4Verified = Boolean(directMp4 && mp4Result?.validUrl !== false && mp4Result?.ok && mp4Result?.statusPass && mp4Result?.contentTypePass);
+  const freshnessResults = ['runtime.health', 'runtime.status']
+    .map((name) => results.find((r) => r.name === name)).filter(Boolean).map(freshnessCheck);
+  const verdict = deriveVerdict(results, assertionResults, claimDriftResults, freshnessResults, directMp4Verified);
 
-  const verdict = deriveVerdict(results, assertionResults, claimDriftResults, manifest);
   const receipt = {
-    schema: 'f5.demo1.public-proof.receipt.v1',
-    generatedAt: nowIso(),
-    strict: STRICT,
-    verifierVersion: '1.1-current-public-bridge-contract',
-    verdict,
-    manifestVideoMp4: directMp4,
+    schema: 'f5.demo1.public-proof.receipt.v3', generatedAt: nowIso(), strict: STRICT,
+    verifierVersion: '3.0-claim-media-freshness-and-scope-safe', verdict,
+    manifestVideoMp4: directMp4, manifestVideoMp4Verified: directMp4Verified,
     fullCommercialGreenAllowed: Boolean(manifest?.claimControl?.fullCommercialGreenAllowed),
     summary: {
       urlsChecked: results.length,
-      failedUrls: results.filter((r) => !r.ok || r.status !== 200).length,
+      failedUrls: results.filter((r) => !r.ok || !r.statusPass).length,
       failedAssertions: assertionResults.filter((r) => !r.pass).length,
       claimDriftFailures: claimDriftResults.filter((r) => !r.pass).length,
+      freshnessFailures: freshnessResults.filter((r) => !r.pass).length,
+      directMp4Checked: Boolean(directMp4), directMp4Verified,
       liveBridgeAssertionsChecked: requiredAssertions.length,
       sourceHardeningAssertionsChecked: hardeningAssertions.length
     },
-    assertionScopes: watchlist.assertionScopes || {
-      requiredAssertions: 'live deployed Squarespace /demo-1 page text and links',
-      requiredHardeningAssertions: 'source-served hardened Squarespace code package'
-    },
-    results,
-    assertionResults,
-    claimDriftResults,
+    assertionScopes: watchlist.assertionScopes,
+    results: results.map(({ body, ...result }) => result), assertionResults, claimDriftResults, freshnessResults,
     claimControl: {
-      allowControlledPreview: verdict !== 'RED',
-      allowDirectMp4Claim: Boolean(directMp4),
+      allowControlledPreview: verdict !== 'RED', allowDirectMp4Claim: directMp4Verified,
       allowFullCommercialGreen: Boolean(manifest?.claimControl?.fullCommercialGreenAllowed) && verdict === 'GREEN'
     }
   };
 
   await fs.mkdir(OUT_DIR, { recursive: true });
-  const outputPath = path.join(OUT_DIR, 'latest-probe.json');
-  await fs.writeFile(outputPath, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+  await fs.writeFile(path.join(OUT_DIR, 'latest-probe.json'), `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
   console.log(JSON.stringify(receipt, null, 2));
-
-  if (STRICT && verdict !== 'GREEN') {
-    process.exitCode = 1;
-  }
+  if (STRICT && verdict !== 'GREEN') process.exitCode = 1;
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+main().catch((error) => { console.error(error); process.exit(1); });


### PR DESCRIPTION
## Purpose

Replaces conflicted PR #154 with a clean current-main implementation.

## Repairs

- preserves the current two-scope `/demo-1` proof contract;
- verifies direct MP4 media before allowing any direct-MP4 claim;
- performs case-insensitive runtime claim-drift checks;
- pins source-served GitHub assets to the current candidate SHA during CI;
- checks `/health` and `/status` receipt freshness with a 15-minute ceiling;
- retains public-proof artifacts for 30 days;
- runs the strict proof workflow on relevant pull requests;
- adds fresh runtime `generatedAt`, revision, release SHA, and no-cache metadata;
- routes production through the public receipt wrapper;
- adds deterministic tests for health/status freshness and cache prevention.

## Deliberately excluded

The stale `cloudbuild.yaml` and `deploy_demo.sh` edits from PR #154 are not carried forward because their service and repository substitutions do not match the current canonical production workflow.

## Claim control

This PR does not claim direct MP4, self-serve commerce, customer portal, native self-healing, or full commercial green. It makes the proof system fail closed until live deployment evidence is current.

Supersedes #154 and #148.