### PR TITLE
Consolidate active Python dependency updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,11 @@ requests>=2.33.0
 google-cloud-core>=2.3.3
 google-cloud-storage>=2.10.0
 google-cloud-secret-manager>=2.16.4
-google-auth>=2.22.0
+google-auth>=2.51.0
 google-api-python-client>=2.97.0
 
 # Docker & Containerization
-docker>=6.1.3
+docker>=7.1.0
 
 # YAML Processing
 PyYAML>=6.0.1
@@ -23,14 +23,14 @@ pandas>=2.0.3
 numpy>=1.24.3
 
 # CLI & Terminal Tools
-click>=8.1.6
+click>=8.3.3
 colorama>=0.4.6
 
 # Utilities
-python-dotenv>=1.0.0
+python-dotenv>=1.2.2
 pathlib>=1.0.1
 
 # Dependency conflict resolution
-sympy>=1.13.1
+sympy>=1.14.0
 pydantic>=2.12.5
 pydantic-core>=2.41.5

--- a/scripts/oauth_server/requirements.txt
+++ b/scripts/oauth_server/requirements.txt
@@ -4,7 +4,7 @@ Flask==3.1.3
 Flask-CORS==6.0.0
 requests==2.33.0
 PyJWT==2.13.0
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 # For automated container management
 # subprocess/threading are standard library
 # For production: gunicorn, eventlet, or uvicorn (optional)


### PR DESCRIPTION
## Purpose

Replaces the conflicted and duplicate Dependabot requirement PRs with one current-main update.

## Active runtime updates

- `python-dotenv` to 1.2.2 in root and OAuth service requirements;
- `click` to 8.3.3;
- `sympy` to 1.14.0;
- `google-auth` to 2.51.0;
- `docker` SDK to 7.1.0;
- preserves the already-merged PyJWT 2.13.0 security update in root and OAuth paths.

## Excluded

Backup-only dependency copies are not promoted into the active runtime and their duplicate bot PRs will be closed.

Supersedes #113, #116, #118, #119, #121, and #122.