### PR TITLE
Consolidate pinned GitHub Action upgrades

### DIFF
--- a/.github/workflows/_docker-build-optimized.yml
+++ b/.github/workflows/_docker-build-optimized.yml
@@ -3,7 +3,6 @@ name: Optimized Docker Build
 permissions:
   contents: read
 
-
 # This is a reusable workflow for cost-effective Docker builds
 on:
   workflow_call:
@@ -23,16 +22,14 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
-      
-      # Use Docker layer caching (saves 60-80% build time)
+
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-      
-      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: ${{ inputs.dockerfile }}
           push: false
-          cache-from: type=gha  # GitHub Actions cache
+          cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: ${{ inputs.image-name }}:latest
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,19 +22,19 @@ jobs:
 
       - name: Enforce ASCII filename policy
         run: bash scripts/check_ascii_filenames.sh
-      
+
       - name: Set up Python
-        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
-      
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest black
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-      
+
       - name: Lint with flake8
         run: |
           flake8 . --exclude=.git,__pycache__,.venv,.venv*,venv,node_modules,build,dist --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -42,7 +42,7 @@ jobs:
 
       - name: Check formatting with black
         run: black --check . --exclude '/(\.git|__pycache__|\.venv.*|venv|node_modules|build|dist|backups)/' || true
-      
+
       - name: Run tests with pytest
         run: |
           if [ -d tests ]; then
@@ -50,7 +50,7 @@ jobs:
           else
             pytest -q
           fi
-      
+
       - name: Validate bash scripts
         run: |
           chmod +x scripts/*.sh *.sh 2>/dev/null || true
@@ -59,8 +59,8 @@ jobs:
               bash -n "$script" || exit 1
             fi
           done
-          echo "✅ All bash scripts validated"
-      
+          echo "All bash scripts validated"
+
       - name: Validate docker-compose
         run: |
           if command -v docker-compose >/dev/null 2>&1; then
@@ -71,8 +71,8 @@ jobs:
             echo "Docker Compose is unavailable on this runner; skipping validation."
             exit 0
           fi
-          echo "✅ docker-compose-mcp.yml is valid"
-  
+          echo "docker-compose-mcp.yml is valid"
+
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
@@ -81,19 +81,19 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      
+
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # 0.34.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         continue-on-error: ${{ vars.ENFORCE_TRIVY_SCAN != 'true' }}
         with:
           scan-type: 'fs'
           scan-ref: '.'
           format: 'sarif'
           output: 'trivy-results.sarif'
-      
+
       - name: Upload Trivy results to GitHub Security
         if: ${{ hashFiles('trivy-results.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -104,7 +104,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      
+
       - name: Check configuration files
         run: |
           echo "Verifying deployment readiness..."
@@ -113,11 +113,11 @@ jobs:
           test -f prometheus.yml || exit 1
           test -f scripts/deploy_mcp_full.sh || exit 1
           test -x scripts/deploy_mcp_full.sh || exit 1
-          echo "✅ All configuration files present and valid"
-      
+          echo "All configuration files present and valid"
+
       - name: Generate deployment report
         run: |
-          echo "## 📊 Deployment Readiness Report" >> $GITHUB_STEP_SUMMARY
+          echo "## Deployment Readiness Report" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Configuration Files" >> $GITHUB_STEP_SUMMARY
           ls -lh docker-compose-mcp.yml .env.mcp.template prometheus.yml >> $GITHUB_STEP_SUMMARY
@@ -125,4 +125,4 @@ jobs:
           echo "### Automation Scripts" >> $GITHUB_STEP_SUMMARY
           ls -lh scripts/*.sh >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Ready for Docker Desktop Pro deployment" >> $GITHUB_STEP_SUMMARY
+          echo "Ready for Docker Desktop Pro deployment" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/cicd-deploy.yml
+++ b/.github/workflows/cicd-deploy.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         if: steps.preflight.outputs.ready == 'true'
-        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ env.WIF_PROVIDER }}
           service_account: ${{ env.WIF_SERVICE_ACCOUNT }}

--- a/.github/workflows/phi-automation-monitor.yml
+++ b/.github/workflows/phi-automation-monitor.yml
@@ -3,10 +3,9 @@ name: PHI Automation Monitor
 permissions:
   contents: read
 
-
 on:
   schedule:
-    - cron: '*/15 * * * *' # every 15 minutes
+    - cron: '*/15 * * * *'
   workflow_dispatch: {}
 
 jobs:
@@ -16,8 +15,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python (for any Python scripts)
-        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
 
@@ -42,4 +41,3 @@ jobs:
           path: |
             scripts/telemetry/*.log
             logs/*.log
-

--- a/.github/workflows/production-deploy-optimized.yml
+++ b/.github/workflows/production-deploy-optimized.yml
@@ -13,7 +13,6 @@ on:
       - '.github/workflows/canon-phi-validation.yml'
   workflow_dispatch:
 
-# Cancel in-progress runs on new commits (saves 20-40%)
 concurrency:
   group: production-deploy-${{ github.ref }}
   cancel-in-progress: true
@@ -22,19 +21,18 @@ jobs:
   test:
     name: Quick Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10  # Prevent runaway costs
-    
+    timeout-minutes: 10
+
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          fetch-depth: 1  # Shallow clone
-      
-      # Aggressive caching
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+          fetch-depth: 1
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
           cache: 'pip'
-      
+
       - name: Cache test dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
@@ -42,17 +40,16 @@ jobs:
             ~/.cache/pip
             .pytest_cache
           key: test-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
-      
+
       - name: Install minimal dependencies
         run: |
           pip install pytest pytest-cov bandit safety --quiet
-      
+
       - name: Fast security scan
         run: |
-          bandit -r . -ll -q || true  # Only high severity
-          safety check --bare || true  # Minimal output
-      
-      # Only run tests if code changed
+          bandit -r . -ll -q || true
+          safety check --bare || true
+
       - name: Check for code changes
         id: changed
         run: |
@@ -61,7 +58,7 @@ jobs:
           else
             echo "code_changed=false" >> $GITHUB_OUTPUT
           fi
-      
+
       - name: Run pytest
         if: steps.changed.outputs.code_changed == 'true'
         run: pytest --tb=short -q
@@ -71,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     timeout-minutes: 15
-    
+
     permissions:
       contents: read
       id-token: write
@@ -81,7 +78,7 @@ jobs:
       SERVICE_NAME: dominion-os-demo
       IMAGE_REPO: us-central1-docker.pkg.dev/dominion-core-prod/dominion-os/dominion-os-demo
       DEPLOY_ENABLED: ${{ vars.ENABLE_PROD_DEPLOY || 'false' }}
-    
+
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -127,26 +124,23 @@ jobs:
           TOKEN_FILE="$RUNNER_TEMP/gcp-access-token.txt"
           printf '%s' "$GCP_ACCESS_TOKEN" > "$TOKEN_FILE"
           echo "token_file=$TOKEN_FILE" >> "$GITHUB_OUTPUT"
-      
-      # Use Docker buildx for layer caching
+
       - if: steps.preflight.outputs.ready == 'true'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-      
+
       - name: Build with cache
         if: steps.preflight.outputs.ready == 'true'
         env:
           CLOUDSDK_AUTH_ACCESS_TOKEN_FILE: ${{ steps.gcp-token.outputs.token_file }}
         run: |
           docker login -u oauth2accesstoken --password-stdin https://us-central1-docker.pkg.dev < "${{ steps.gcp-token.outputs.token_file }}"
-          
-          # Build with GitHub Actions cache
           docker buildx build \
             --cache-from type=gha \
             --cache-to type=gha,mode=max \
             --tag ${IMAGE_REPO}:${{ github.sha }} \
             --push \
             .
-      
+
       - name: Deploy to Cloud Run
         if: steps.preflight.outputs.ready == 'true'
         env:
@@ -168,8 +162,7 @@ jobs:
         if: steps.preflight.outputs.ready != 'true'
         run: |
           echo "Skipping cost-optimized deploy. Missing prerequisites: ${{ steps.preflight.outputs.missing }}"
-      
-      # No artifact upload unless failure
+
       - name: Upload failure logs
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -177,5 +170,5 @@ jobs:
           name: deploy-failure-logs
           path: |
             *.log
-          retention-days: 3  # Minimal retention
+          retention-days: 3
           compression-level: 9


### PR DESCRIPTION
## Purpose

Replaces five overlapping Dependabot action PRs with one current-main, immutable-SHA update.

## Upgrades

- `actions/setup-python` to 6.2.0 across CI, monitoring, and optimized deploy;
- `aquasecurity/trivy-action` to 0.36.0;
- `github/codeql-action/upload-sarif` to 4.35.3;
- `docker/build-push-action` to 7.1.0;
- `google-github-actions/auth` to 3.0.0.

## Supply-chain posture

All actions remain pinned to exact commit SHAs. The stale CodeQL PR's mutable `v4.35.3` tags are deliberately not carried into the current applicability workflow.

Supersedes #112, #114, #115, #117, and #120.