### PR TITLE
Add governed full commercial launch closeout package

### DIFF
--- a/.github/workflows/full-commercial-launch-gate.yml
+++ b/.github/workflows/full-commercial-launch-gate.yml
@@ -1,0 +1,64 @@
+name: full-commercial-launch-gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: package validates implementation; live requires all external receipts
+        required: true
+        default: package
+        type: choice
+        options:
+          - package
+          - live
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'demo/assets/full-commercial-launch-contract.json'
+      - 'docs/commercial/**'
+      - 'docs/operations/**'
+      - 'tools/verify-full-commercial-launch.mjs'
+      - '.github/workflows/full-commercial-launch-gate.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'demo/assets/full-commercial-launch-contract.json'
+      - 'docs/commercial/**'
+      - 'docs/operations/**'
+      - 'tools/verify-full-commercial-launch.mjs'
+      - '.github/workflows/full-commercial-launch-gate.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: full-commercial-launch-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify commercial launch contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Verify launch package
+        env:
+          LAUNCH_PROOF_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'package' }}
+          OUT_DIR: out/full-commercial-launch
+        run: node tools/verify-full-commercial-launch.mjs
+
+      - name: Upload public-safe launch receipt
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: full-commercial-launch-receipt
+          path: out/full-commercial-launch/latest.json
+          if-no-files-found: error
+          retention-days: 30

--- a/demo/assets/full-commercial-launch-contract.json
+++ b/demo/assets/full-commercial-launch-contract.json
@@ -1,0 +1,57 @@
+{
+  "schema": "f5.dominion.full-commercial-launch-contract.v1",
+  "generatedAt": "2026-07-16T23:59:00Z",
+  "commercialMode": "controlled-invoice-only",
+  "selfServeCheckoutClaimed": false,
+  "customerPortalClaimed": false,
+  "autonomousSelfHealingClaimed": false,
+  "requiredDocuments": [
+    "docs/commercial/INVOICE_ONLY_SALES_MOTION.md",
+    "docs/commercial/CUSTOMER_LIFECYCLE.md",
+    "docs/operations/INCIDENT_RESPONSE_AND_ROLLBACK.md"
+  ],
+  "gates": {
+    "publicProofIntegrity": {
+      "status": "GREEN",
+      "evidence": "PR #159 exact-head public-proof workflow and retained artifact"
+    },
+    "currentCiSecurity": {
+      "status": "GREEN",
+      "evidence": "Current codeql, governance, dependency review, security scan, Canon compliance, and PHI + MCP workflows passed on the latest maintenance candidate"
+    },
+    "authoritativePublicRuntimeCutover": {
+      "status": "BLOCKED_EXTERNAL_EXECUTION",
+      "requiredReceipt": "Authorized deployment receipt identifying exact GCP project, region, service, revision, image digest, operator, timestamp, and post-deploy public proof"
+    },
+    "invoiceProcurement": {
+      "status": "BLOCKED_REAL_BUYER_EVENT",
+      "requiredReceipt": "Redacted accepted quote/order and invoice or procurement reference"
+    },
+    "customerLifecycle": {
+      "status": "BLOCKED_REAL_BUYER_EVENT",
+      "requiredReceipt": "Redacted onboarding, entitlement ownership, support, and offboarding-readiness receipt"
+    },
+    "observabilityAlerting": {
+      "status": "BLOCKED_EXTERNAL_EXECUTION",
+      "requiredReceipt": "Current uptime/SLO, alert routing, log/metric retention, and notification test receipt for the authoritative service"
+    },
+    "rollbackIncidentResponse": {
+      "status": "BLOCKED_EXTERNAL_EXECUTION",
+      "requiredReceipt": "Authorized rollback or recovery exercise receipt"
+    },
+    "directMp4": {
+      "status": "NOT_REQUIRED_FOR_INVOICE_ONLY_LAUNCH",
+      "rule": "No direct MP4 claim is allowed while the manifest URL is null"
+    },
+    "autonomousOperations": {
+      "status": "NOT_CLAIMED_NOT_REQUIRED",
+      "rule": "Do not claim autonomous remediation or native self-healing without separate auditable evidence"
+    }
+  },
+  "claimControl": {
+    "controlledInvoiceOnlyCommercialLaunchAllowed": false,
+    "fullSelfServeSaasLaunchAllowed": false,
+    "fullCommercialGreenAllowed": false,
+    "promotionRule": "Only set controlledInvoiceOnlyCommercialLaunchAllowed true after runtime, procurement, customer lifecycle, observability, and rollback exercise receipts are current. Full self-serve SaaS remains a separate future gate."
+  }
+}

--- a/docs/commercial/CUSTOMER_LIFECYCLE.md
+++ b/docs/commercial/CUSTOMER_LIFECYCLE.md
@@ -1,0 +1,58 @@
+# Dominion OS™ + SaaS Suite — Customer Lifecycle Control
+
+## Scope
+
+This document governs controlled commercial customers until automated tenant provisioning and a customer portal are separately implemented and proven.
+
+## Onboarding
+
+Before access is granted, record:
+
+- accepted order, statement of work, or procurement authorization;
+- named customer sponsor and Fractal5 service owner;
+- approved users and least-privilege roles;
+- deployment and data boundary;
+- prohibited data classes;
+- support channel and response target;
+- start date, term, and review date;
+- acceptance test and rollback owner.
+
+Credentials must be delivered through an approved private channel. They must never appear in public receipts, email bodies containing unrelated parties, source control, or public demo assets.
+
+## Entitlement lifecycle
+
+Each entitlement requires a unique internal reference and must record:
+
+- product or service scope;
+- authorized organization and users;
+- role and permissions;
+- effective and expiry dates;
+- provisioning approver;
+- last access review;
+- suspension and revocation state.
+
+Access reviews occur at onboarding, material scope change, renewal, suspected compromise, and offboarding.
+
+## Support
+
+Commercial customers receive a named support path. Support records classify severity, customer impact, data sensitivity, owner, response, resolution, and follow-up. No production credentials or confidential payloads enter public issue trackers.
+
+## Cancellation, refund, and offboarding
+
+The written order controls financial terms. Fractal5 must:
+
+1. acknowledge cancellation or non-renewal;
+2. stop new use at the agreed time;
+3. revoke credentials and entitlements;
+4. preserve legally required commercial records;
+5. return or delete customer-provided data according to the agreement;
+6. record completion and unresolved obligations;
+7. issue any approved credit or refund through the accounting process.
+
+## Privacy and data handling
+
+Default posture is data minimization. The public demo contains no customer data. A commercial deployment may process only data explicitly authorized by the order and documented boundary. Sensitive or regulated data requires a separate written review before ingestion.
+
+## Evidence gate
+
+The lifecycle gate becomes GREEN only when a real customer onboarding produces a private operational record and a public-safe redacted receipt proving provisioning, entitlement ownership, support path, and offboarding readiness without exposing customer information.

--- a/docs/commercial/INVOICE_ONLY_SALES_MOTION.md
+++ b/docs/commercial/INVOICE_ONLY_SALES_MOTION.md
@@ -1,0 +1,41 @@
+# Dominion OS™ + SaaS Suite — Invoice-Only Commercial Sales Motion
+
+## Launch decision
+
+Fractal5 may sell Dominion OS™ + SaaS Suite through a governed, invoice-only commercial motion. Self-serve checkout, automated subscription billing, and a customer portal are outside the launch claim until separately implemented and receipted.
+
+## Buyer path
+
+1. Prospect receives the canonical public proof bridge at `/demo-1`.
+2. Prospect requests a commercial discussion through an approved Fractal5 contact channel.
+3. Fractal5 confirms scope, authorized users, deployment boundary, data classification, support level, price, taxes, term, cancellation terms, and acceptance criteria.
+4. Fractal5 issues a written quote, statement of work, or order form.
+5. Buyer accepts in writing and receives an invoice through the approved accounting process.
+6. Access is provisioned only after the approval condition stated in the order is met.
+7. The commercial file records the order identifier, invoice identifier, entitlement owner, effective date, renewal/end date, and support contact. No payment-card data is stored in this repository.
+
+## Minimum commercial record
+
+A launch-closing procurement receipt must identify, without exposing confidential buyer data publicly:
+
+- dated quote/order acceptance;
+- invoice or procurement reference;
+- product and scope;
+- commercial term;
+- entitlement owner;
+- provisioning authorization;
+- support and cancellation path;
+- privacy/data-processing posture;
+- redacted proof that the transaction or procurement step occurred.
+
+## Controls
+
+- No service is represented as self-serve.
+- No customer portal is represented as live.
+- No payment data, customer secrets, credentials, or private contractual terms enter public demo assets.
+- Discounts, refunds, credits, renewals, and cancellations require an auditable written decision.
+- Marketing claims must remain within current public proof receipts.
+
+## Launch gate
+
+This process is operationally ready when the templates and lifecycle controls are approved. The payment/procurement gate becomes evidence-backed only after one genuine accepted order or invoice/procurement event is recorded in a private commercial file and a public-safe redacted receipt is published.

--- a/docs/launch-readiness/2026-07-16-full-commercial-launch-closeout.md
+++ b/docs/launch-readiness/2026-07-16-full-commercial-launch-closeout.md
@@ -24,8 +24,9 @@ The immediate launch target is a governed **controlled invoice-only commercial s
 5. Conduct an authorized rollback/recovery exercise and retain a redacted receipt.
 6. Complete one genuine accepted quote/order and invoice or procurement event.
 7. Provision one real customer under the lifecycle control and retain a redacted onboarding/entitlement/support receipt.
-8. Update `demo/assets/full-commercial-launch-contract.json` only from those receipts and run the workflow in `live` mode.
-9. Promote `controlledInvoiceOnlyCommercialLaunchAllowed` only when the live-mode receipt is GREEN.
+8. Update each required live gate in `demo/assets/full-commercial-launch-contract.json` to `GREEN` only when it contains a current public-safe receipt reference, then run the verifier in `live` mode to confirm `liveEvidenceVerdict: GREEN` while launch flags remain fail-closed.
+9. Set only `controlledInvoiceOnlyCommercialLaunchAllowed` to `true`; keep self-serve SaaS and full-commercial flags false.
+10. Run the workflow in `live` mode again. Promote controlled invoice-only launch only when `commercialLaunchVerdict: GREEN` is emitted.
 
 ## Claim boundary
 

--- a/docs/launch-readiness/2026-07-16-full-commercial-launch-closeout.md
+++ b/docs/launch-readiness/2026-07-16-full-commercial-launch-closeout.md
@@ -1,0 +1,38 @@
+# Full commercial launch closeout — 2026-07-16
+
+## Commercial launch definition
+
+The immediate launch target is a governed **controlled invoice-only commercial service**, not self-serve SaaS. This avoids unsupported checkout, portal, automated billing, and autonomous-operation claims while still allowing real customers to buy, onboard, receive controlled access, obtain support, and offboard under written terms.
+
+## Completed in the repository
+
+- exact-PR-source public proof and retained artifacts;
+- current dependency and pinned-action maintenance;
+- invoice-only sales motion;
+- onboarding, entitlement, support, cancellation, refund, privacy, and offboarding controls;
+- incident-response and rollback runbook;
+- machine-readable fail-closed launch contract;
+- package-versus-live launch verifier;
+- GitHub Actions receipt workflow.
+
+## External execution sequence
+
+1. Identify the authoritative public Cloud Run project, region, service, deployment identity, and stable rollback revision.
+2. Deploy current safe source to that exact target.
+3. Verify revision/image identity, fresh `/health` and `/status`, corrected `/demo` claims, and the strict public-proof receipt.
+4. Configure an uptime objective, alert destination, log/metric retention posture, and execute an alert test.
+5. Conduct an authorized rollback/recovery exercise and retain a redacted receipt.
+6. Complete one genuine accepted quote/order and invoice or procurement event.
+7. Provision one real customer under the lifecycle control and retain a redacted onboarding/entitlement/support receipt.
+8. Update `demo/assets/full-commercial-launch-contract.json` only from those receipts and run the workflow in `live` mode.
+9. Promote `controlledInvoiceOnlyCommercialLaunchAllowed` only when the live-mode receipt is GREEN.
+
+## Claim boundary
+
+Full commercial launch does not require a direct MP4, self-serve checkout, customer portal, or autonomous self-healing when those capabilities are not claimed. It does require a real buyer path, controlled access lifecycle, operational monitoring, tested recovery, security evidence, and an authoritative production deployment.
+
+## Current verdict
+
+`PACKAGE_READY_EXTERNAL_EXECUTION_PENDING`
+
+Repository and process preparation are ready for review. Full commercial GREEN remains prohibited until the authoritative deployment, observability test, rollback exercise, procurement event, and customer lifecycle receipts exist.

--- a/docs/operations/INCIDENT_RESPONSE_AND_ROLLBACK.md
+++ b/docs/operations/INCIDENT_RESPONSE_AND_ROLLBACK.md
@@ -1,0 +1,50 @@
+# Dominion OS™ + SaaS Suite — Incident Response and Rollback
+
+## Operating objective
+
+Detect, contain, recover, communicate, and learn without exposing secrets or overstating automation.
+
+## Severity
+
+- **SEV-1:** broad outage, confirmed data exposure, unauthorized privileged access, or material customer harm.
+- **SEV-2:** major degradation, failed deployment, repeated errors, or loss of an important commercial function.
+- **SEV-3:** limited defect with a workaround and no confirmed security or data impact.
+
+## Response sequence
+
+1. Open a private incident record with UTC start time, reporter, affected service, current revision, and known customer impact.
+2. Assign an incident commander and technical owner.
+3. Preserve relevant logs, metrics, deployment metadata, and public-safe health receipts.
+4. Contain the issue: disable the affected function, restrict traffic, revoke compromised access, or freeze deployments as appropriate.
+5. Decide recovery: configuration repair, forward fix, or rollback.
+6. Verify `/health`, `/status`, core customer path, access controls, and public claim boundaries after recovery.
+7. Communicate status through the approved customer/support channel.
+8. Record resolution, contributing factors, corrective actions, owners, and due dates.
+
+## Cloud Run rollback procedure
+
+Before any commercial deployment, record the current stable revision and traffic allocation. A rollback must:
+
+1. identify the last verified revision;
+2. move traffic to that revision through the authorized Cloud Run project and service;
+3. verify the revision identity and image digest;
+4. confirm fresh health/status timestamps;
+5. run the public proof verifier;
+6. confirm customer access and entitlement behavior;
+7. record operator, UTC time, reason, command or console action, outcome, and receipt locations.
+
+No rollback command may be executed until the authoritative project, region, service, and revision are confirmed. Repository prose is not authority for an unknown live service.
+
+## Recovery validation
+
+Recovery is complete only when:
+
+- route and asset probes pass;
+- security and public-boundary checks pass;
+- no stale or unsupported MP4, commerce, portal, observability, or autonomous-operation claim remains;
+- customer-impact assessment is recorded;
+- follow-up actions have owners.
+
+## Evidence gate
+
+The rollback and incident-response gate becomes GREEN after one authorized non-production exercise or real incident produces a public-safe redacted receipt showing detection, decision, rollback or recovery, verification, and review. A written runbook alone is readiness evidence, not execution evidence.

--- a/tools/verify-full-commercial-launch.mjs
+++ b/tools/verify-full-commercial-launch.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const CONTRACT_PATH = path.join(ROOT, 'demo/assets/full-commercial-launch-contract.json');
+const OUT_DIR = process.env.OUT_DIR || path.join(ROOT, 'out/full-commercial-launch');
+const MODE = String(process.env.LAUNCH_PROOF_MODE || 'package').toLowerCase();
+
+const nowIso = () => new Date().toISOString();
+const readJson = async (p) => JSON.parse(await fs.readFile(p, 'utf8'));
+
+async function exists(relativePath) {
+  try {
+    const stat = await fs.stat(path.join(ROOT, relativePath));
+    return stat.isFile() && stat.size > 0;
+  } catch {
+    return false;
+  }
+}
+
+function collectExternalBlockers(contract) {
+  return Object.entries(contract.gates || {})
+    .filter(([, gate]) => String(gate.status || '').startsWith('BLOCKED_'))
+    .map(([name, gate]) => ({ name, status: gate.status, requiredReceipt: gate.requiredReceipt || null }));
+}
+
+async function main() {
+  const contract = await readJson(CONTRACT_PATH);
+  const documentChecks = [];
+  for (const relativePath of contract.requiredDocuments || []) {
+    documentChecks.push({ path: relativePath, pass: await exists(relativePath) });
+  }
+
+  const packageIntegrity = documentChecks.every((item) => item.pass)
+    && contract.commercialMode === 'controlled-invoice-only'
+    && contract.selfServeCheckoutClaimed === false
+    && contract.customerPortalClaimed === false
+    && contract.autonomousSelfHealingClaimed === false;
+
+  const externalBlockers = collectExternalBlockers(contract);
+  const liveGreen = packageIntegrity
+    && externalBlockers.length === 0
+    && contract.claimControl?.controlledInvoiceOnlyCommercialLaunchAllowed === true;
+
+  const receipt = {
+    schema: 'f5.dominion.full-commercial-launch-receipt.v1',
+    generatedAt: nowIso(),
+    mode: MODE,
+    packageIntegrityVerdict: packageIntegrity ? 'GREEN' : 'RED',
+    commercialLaunchVerdict: liveGreen ? 'GREEN' : 'AMBER_BLOCKED',
+    documentChecks,
+    externalBlockers,
+    claimControl: contract.claimControl || {}
+  };
+
+  await fs.mkdir(OUT_DIR, { recursive: true });
+  await fs.writeFile(path.join(OUT_DIR, 'latest.json'), `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+  console.log(JSON.stringify(receipt, null, 2));
+
+  if (!packageIntegrity) process.exitCode = 1;
+  if (MODE === 'live' && !liveGreen) process.exitCode = 2;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tools/verify-full-commercial-launch.mjs
+++ b/tools/verify-full-commercial-launch.mjs
@@ -7,6 +7,20 @@ const CONTRACT_PATH = path.join(ROOT, 'demo/assets/full-commercial-launch-contra
 const OUT_DIR = process.env.OUT_DIR || path.join(ROOT, 'out/full-commercial-launch');
 const MODE = String(process.env.LAUNCH_PROOF_MODE || 'package').toLowerCase();
 
+const REQUIRED_DOCUMENTS = [
+  'docs/commercial/INVOICE_ONLY_SALES_MOTION.md',
+  'docs/commercial/CUSTOMER_LIFECYCLE.md',
+  'docs/operations/INCIDENT_RESPONSE_AND_ROLLBACK.md'
+];
+
+const REQUIRED_LIVE_GATES = [
+  'authoritativePublicRuntimeCutover',
+  'invoiceProcurement',
+  'customerLifecycle',
+  'observabilityAlerting',
+  'rollbackIncidentResponse'
+];
+
 const nowIso = () => new Date().toISOString();
 const readJson = async (p) => JSON.parse(await fs.readFile(p, 'utf8'));
 
@@ -19,39 +33,79 @@ async function exists(relativePath) {
   }
 }
 
-function collectExternalBlockers(contract) {
-  return Object.entries(contract.gates || {})
-    .filter(([, gate]) => String(gate.status || '').startsWith('BLOCKED_'))
-    .map(([name, gate]) => ({ name, status: gate.status, requiredReceipt: gate.requiredReceipt || null }));
+function gateIsReceiptBackedGreen(gate) {
+  if (!gate || gate.status !== 'GREEN') return false;
+  const evidence = gate.evidence || gate.receipt || gate.receiptPath || gate.publicReceipt;
+  return typeof evidence === 'string' && evidence.trim().length > 0;
 }
 
 async function main() {
   const contract = await readJson(CONTRACT_PATH);
+  const configuredDocuments = contract.requiredDocuments;
+  const requiredDocumentContractValid = Array.isArray(configuredDocuments)
+    && configuredDocuments.length === REQUIRED_DOCUMENTS.length
+    && REQUIRED_DOCUMENTS.every((item) => configuredDocuments.includes(item));
+
   const documentChecks = [];
-  for (const relativePath of contract.requiredDocuments || []) {
-    documentChecks.push({ path: relativePath, pass: await exists(relativePath) });
+  for (const relativePath of REQUIRED_DOCUMENTS) {
+    documentChecks.push({
+      path: relativePath,
+      declared: Array.isArray(configuredDocuments) && configuredDocuments.includes(relativePath),
+      pass: await exists(relativePath)
+    });
   }
 
-  const packageIntegrity = documentChecks.every((item) => item.pass)
+  const claimControl = contract.claimControl || {};
+  const launchFlagsFailClosed = claimControl.controlledInvoiceOnlyCommercialLaunchAllowed === false
+    && claimControl.fullSelfServeSaasLaunchAllowed === false
+    && claimControl.fullCommercialGreenAllowed === false;
+
+  const packageIntegrity = requiredDocumentContractValid
+    && documentChecks.every((item) => item.declared && item.pass)
     && contract.commercialMode === 'controlled-invoice-only'
     && contract.selfServeCheckoutClaimed === false
     && contract.customerPortalClaimed === false
-    && contract.autonomousSelfHealingClaimed === false;
+    && contract.autonomousSelfHealingClaimed === false
+    && (MODE === 'live' || launchFlagsFailClosed);
 
-  const externalBlockers = collectExternalBlockers(contract);
-  const liveGreen = packageIntegrity
-    && externalBlockers.length === 0
-    && contract.claimControl?.controlledInvoiceOnlyCommercialLaunchAllowed === true;
+  const liveGateChecks = REQUIRED_LIVE_GATES.map((name) => {
+    const gate = contract.gates?.[name];
+    return {
+      name,
+      status: gate?.status || 'MISSING',
+      evidence: gate?.evidence || gate?.receipt || gate?.receiptPath || gate?.publicReceipt || null,
+      pass: gateIsReceiptBackedGreen(gate)
+    };
+  });
+
+  const externalBlockers = liveGateChecks
+    .filter((gate) => !gate.pass)
+    .map((gate) => ({
+      name: gate.name,
+      status: gate.status,
+      requiredReceipt: contract.gates?.[gate.name]?.requiredReceipt || null
+    }));
+
+  const liveEvidenceGreen = packageIntegrity && liveGateChecks.every((gate) => gate.pass);
+  const promotionFlagSet = claimControl.controlledInvoiceOnlyCommercialLaunchAllowed === true;
+  const incompatibleClaimsRemainFalse = claimControl.fullSelfServeSaasLaunchAllowed === false
+    && claimControl.fullCommercialGreenAllowed === false;
+  const liveGreen = liveEvidenceGreen && promotionFlagSet && incompatibleClaimsRemainFalse;
 
   const receipt = {
-    schema: 'f5.dominion.full-commercial-launch-receipt.v1',
+    schema: 'f5.dominion.full-commercial-launch-receipt.v2',
     generatedAt: nowIso(),
     mode: MODE,
     packageIntegrityVerdict: packageIntegrity ? 'GREEN' : 'RED',
+    liveEvidenceVerdict: liveEvidenceGreen ? 'GREEN' : 'AMBER_BLOCKED',
     commercialLaunchVerdict: liveGreen ? 'GREEN' : 'AMBER_BLOCKED',
+    requiredDocumentContractValid,
+    launchFlagsFailClosed,
+    promotionFlagSet,
     documentChecks,
+    liveGateChecks,
     externalBlockers,
-    claimControl: contract.claimControl || {}
+    claimControl
   };
 
   await fs.mkdir(OUT_DIR, { recursive: true });


### PR DESCRIPTION
## Purpose

Converts the remaining full-commercial-launch blockers into an executable, fail-closed launch package.

## Commercial model

The immediate launch target is controlled invoice-only commercial access. This deliberately does not claim self-serve checkout, automated billing, a customer portal, direct MP4, or autonomous self-healing.

## Adds

- governed invoice-only sales motion;
- customer onboarding, entitlement, support, cancellation, refund, privacy, and offboarding controls;
- incident-response and Cloud Run rollback runbook;
- machine-readable full-commercial-launch contract;
- package-versus-live launch verifier;
- GitHub Actions receipt workflow with 30-day artifact retention;
- closeout ledger defining the exact external execution sequence.

## Fail-closed behavior

PR/package mode proves the launch package is internally complete. Live mode remains AMBER until real receipts exist for the authoritative Cloud Run cutover, uptime/alert test, rollback exercise, accepted order or invoice/procurement event, and customer onboarding/entitlement lifecycle.

No secrets, payment-card data, customer data, credentials, or private contractual terms are included.