### PR TITLE
Normalize public demo naming

### DIFF
--- a/demo/assets/demo-download-package.json
+++ b/demo/assets/demo-download-package.json
@@ -1,7 +1,7 @@
 {
   "schema": "f5.dominion.demo.download-package.v1",
-  "generatedAt": "2026-06-07T00:00:00Z",
-  "title": "Dominion OS 1.0 Public Demo Package",
+  "generatedAt": "2026-07-16T23:59:00Z",
+  "title": "Dominion OS + SaaS Suite Public Demo Package",
   "publicBridge": "https://www.fractal5solutions.com/demo-1",
   "runtimeDemo": "https://demo-reduwyf2ra-uc.a.run.app/demo",
   "contents": [

--- a/demo/assets/release-receipts.json
+++ b/demo/assets/release-receipts.json
@@ -1,8 +1,8 @@
 {
   "schema": "f5.dominion.demo.release-receipts.v1",
-  "generatedAt": "2026-06-07T00:00:00Z",
+  "generatedAt": "2026-07-16T23:59:00Z",
   "release": {
-    "name": "Dominion OS 1.0 Live Demo",
+    "name": "Dominion OS + SaaS Suite Public Demo",
     "publicBridge": "https://www.fractal5solutions.com/demo-1",
     "runtimeDemo": "https://demo-reduwyf2ra-uc.a.run.app/demo",
     "environment": "demo-sandbox"

--- a/docs/launch-readiness/receipts/2026-07-16-naming-normalization.json
+++ b/docs/launch-readiness/receipts/2026-07-16-naming-normalization.json
@@ -1,0 +1,16 @@
+{
+  "schema": "f5.dominion.public-naming-receipt.v1",
+  "generatedAt": "2026-07-16T23:59:00Z",
+  "scope": [
+    "demo/assets/release-receipts.json",
+    "demo/assets/demo-download-package.json"
+  ],
+  "canonicalPublicName": "Dominion OS + SaaS Suite",
+  "schemaIdentifiersPreserved": true,
+  "claimBoundaryUnchanged": true,
+  "directMp4Claimed": false,
+  "fullCommercialGreenClaimed": false,
+  "containsSecrets": false,
+  "containsCustomerData": false,
+  "containsPaymentData": false
+}


### PR DESCRIPTION
Updates two public demo asset labels to Dominion OS + SaaS Suite, preserves schema identifiers, and adds a public-safe receipt. No launch claims are widened.