### PR TITLE
docs(codex-charter): add AGENTS.md and .codex/config.toml

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,13 @@
+# Project-scoped Codex defaults for dominion-os-demo-build.
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+web_search = "cached"
+model_reasoning_effort = "high"
+personality = "pragmatic"
+project_doc_max_bytes = 32768
+
+[features]
+shell_snapshot = true
+multi_agent = true
+hooks = true
+fast_mode = false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# dominion-os-demo-build — Codex Instructions
+
+## Operating Role
+
+Codex is the engineering execution surface for this repo. GitHub is source
+control and proof. Matthew retains final production authority. This repo is the
+public-safe serving surface only — it is NOT control-plane or runtime authority.
+
+## Workspace
+
+- Remote: Fractal5-Solutions/dominion-os-demo-build
+- Default/protected branch: `main` (PR-only)
+- OS/shell: Windows/PowerShell; Python (`requirements.txt`).
+- WSL `/mnt/d/phi-ops` only for Linux-native paths. VS Code optional.
+
+## Context Intake
+
+1. This `AGENTS.md` -> 2. `README.md` -> 3. `.github/workflows/*` -> 4. targeted `rg`.
+
+## Commands
+
+- Install: `pip install -r requirements.txt` (operator-approved env)
+- Test: `test-minimal.yml`, `canon-phi-validation.yml`
+- Security: `secret-scan.yml`, `security-scan.yml`, `codeql.yml`
+- Launch gate: `full-commercial-launch-gate.yml`
+
+## Deploy
+
+- Deploy workflows: `cicd-deploy.yml`, `production-deploy.yml`, `cloudrun-private-gate.yml`
+  — manual dispatch, env-protected, operator-approved. Public-serving target.
+- Rollback: redeploy prior signed tag; simulate first.
+
+## Editing Rules
+
+- Feature branch off `main`; draft PR early. Preserve unrelated dirty changes; keep scoped.
+- Production, public release, secrets, paid APIs, GCloud/Cloud Run, Codespaces, paid
+  runners, and destructive actions require operator approval.
+- Never introduce control-plane logic or secrets into this public-safe repo.
+
+## Secrets
+
+- Reference by name/location only; never reproduce values.
+
+## Definition of Done
+
+- Security scans clean + launch-gate green + diff reviewed + conventional-commit PR;
+  public release additionally requires operator approval.
+
+## Boundaries
+
+Global charter: `D:\phi-ops\docs\codex-charter\00-CODEX-OPERATING-CHARTER.md`;
+cost guardrails: `05-COST-AND-AUTHORITY-GUARDRAILS.md`. GitHub Copilot excluded.


### PR DESCRIPTION
Codex cutover for dominion-os-demo-build (public-safe serving surface): adds AGENTS.md and .codex/config.toml.

## Adds
- AGENTS.md: role (public-safe serving only, NOT control-plane), commands (pip install, test-minimal, security scans, full-commercial-launch-gate), deploy workflows, editing rules, secrets-by-name-only, DoD (security scans clean + launch-gate green), global charter boundaries.
- .codex/config.toml: on-request approvals, workspace-write sandbox, high reasoning, fast_mode off.

## Scope / safety
- No secrets, no Copilot dependence, no deploy, no merge. Draft; not for merge without operator review.
- This repo must remain public-safe: no control-plane logic or secrets introduced.

## Companion
- phi-ops root cutover: Fractal5-Solutions/phi-ops#40 (charter package).
- dominion-command-center cutover: Fractal5-Solutions/dominion-command-center#692.
- dominion-os-core acceptance trial: Fractal5-X/dominion-os-core#12.