### PR TITLE
ops(demo): observe OIDC deployment and public receipt

### DIFF
--- a/.github/workflows/public-demo-deploy-observer.yml
+++ b/.github/workflows/public-demo-deploy-observer.yml
@@ -1,0 +1,249 @@
+name: Observe public demo deployment
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/public-demo-deploy-observer.yml'
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: public-demo-deploy-observer
+  cancel-in-progress: true
+
+jobs:
+  observe:
+    name: Observe OIDC deployment and public proof
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Observe deployment workflow and probe public routes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          HEAD_SHA: ${{ github.sha }}
+          ISSUE_NUMBER: '180'
+          DEPLOY_WORKFLOW: cicd-deploy.yml
+          PUBLIC_BASE_URL: https://demo-reduwyf2ra-uc.a.run.app
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import time
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          token = os.environ['GH_TOKEN']
+          repository = os.environ['REPOSITORY']
+          head_sha = os.environ['HEAD_SHA']
+          issue_number = os.environ['ISSUE_NUMBER']
+          deploy_workflow = os.environ['DEPLOY_WORKFLOW']
+          public_base = os.environ['PUBLIC_BASE_URL'].rstrip('/')
+          api_base = f'https://api.github.com/repos/{repository}'
+          headers = {
+              'Authorization': f'Bearer {token}',
+              'Accept': 'application/vnd.github+json',
+              'X-GitHub-Api-Version': '2022-11-28',
+              'User-Agent': 'fractal5-public-demo-deploy-observer/1.0',
+          }
+
+          def request_json(url, method='GET', payload=None):
+              data = None
+              request_headers = dict(headers)
+              if payload is not None:
+                  data = json.dumps(payload).encode('utf-8')
+                  request_headers['Content-Type'] = 'application/json'
+              request = urllib.request.Request(
+                  url,
+                  data=data,
+                  method=method,
+                  headers=request_headers,
+              )
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  return json.loads(response.read().decode('utf-8'))
+
+          def fetch_run_jobs(run_id):
+              return request_json(
+                  f'{api_base}/actions/runs/{run_id}/jobs?per_page=100'
+              ).get('jobs', [])
+
+          query = urllib.parse.urlencode({
+              'branch': 'main',
+              'event': 'push',
+              'per_page': '20',
+          })
+          runs_url = f'{api_base}/actions/workflows/{deploy_workflow}/runs?{query}'
+          deployment = None
+          jobs = []
+          api_error = None
+
+          for _ in range(96):
+              try:
+                  payload = request_json(runs_url)
+                  deployment = next(
+                      (
+                          run
+                          for run in payload.get('workflow_runs', [])
+                          if run.get('head_sha') == head_sha
+                      ),
+                      None,
+                  )
+                  if deployment is not None:
+                      jobs = fetch_run_jobs(deployment['id'])
+                      if deployment.get('status') == 'completed':
+                          break
+              except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as error:
+                  api_error = str(error)
+              time.sleep(5)
+
+          route_results = []
+          parsed_receipts = {}
+          for path in ('/demo', '/health', '/status'):
+              url = public_base + path
+              status = None
+              content_type = ''
+              cache_control = ''
+              body = ''
+              error_text = ''
+              try:
+                  request = urllib.request.Request(
+                      url,
+                      headers={'User-Agent': 'fractal5-public-demo-deploy-observer/1.0'},
+                  )
+                  with urllib.request.urlopen(request, timeout=25) as response:
+                      status = response.status
+                      content_type = response.headers.get('content-type', '')
+                      cache_control = response.headers.get('cache-control', '')
+                      body = response.read(1_000_000).decode('utf-8', errors='replace')
+              except urllib.error.HTTPError as error:
+                  status = error.code
+                  content_type = error.headers.get('content-type', '') if error.headers else ''
+                  cache_control = error.headers.get('cache-control', '') if error.headers else ''
+                  body = error.read(1_000_000).decode('utf-8', errors='replace')
+                  error_text = str(error)
+              except (urllib.error.URLError, TimeoutError) as error:
+                  error_text = str(error)
+
+              if path in ('/health', '/status') and body:
+                  try:
+                      parsed_receipts[path] = json.loads(body)
+                  except json.JSONDecodeError:
+                      parsed_receipts[path] = {}
+
+              route_results.append({
+                  'path': path,
+                  'status': status,
+                  'content_type': content_type,
+                  'cache_control': cache_control,
+                  'error': error_text,
+              })
+
+          health = parsed_receipts.get('/health', {})
+          status_receipt = parsed_receipts.get('/status', {})
+          release_sha = (
+              health.get('releaseCandidateSha')
+              or status_receipt.get('releaseCandidateSha')
+              or health.get('release_sha')
+              or status_receipt.get('release_sha')
+              or ''
+          )
+          routes_green = all(item.get('status') == 200 for item in route_results)
+          no_store = all(
+              'no-store' in (item.get('cache_control') or '').lower()
+              for item in route_results
+              if item['path'] in ('/health', '/status')
+          )
+          release_matches = release_sha == head_sha
+          public_pass = routes_green and no_store and release_matches
+
+          def step_snapshot(job_list):
+              snapshots = []
+              for job in job_list:
+                  for step in job.get('steps', []) or []:
+                      snapshots.append({
+                          'job': job.get('name') or 'unnamed',
+                          'name': step.get('name') or 'unnamed',
+                          'status': step.get('status') or 'unknown',
+                          'conclusion': step.get('conclusion') or 'none',
+                      })
+              return snapshots
+
+          steps = step_snapshot(jobs)
+          step_by_name = {item['name']: item for item in steps}
+          skip_step = step_by_name.get('Skip summary')
+          submit_step = step_by_name.get('Submit Cloud Build')
+          verify_step = step_by_name.get('Verify public deployment')
+
+          lines = [
+              '## Public demo deployment observer',
+              '',
+              f'- Observed commit: `{head_sha}`',
+          ]
+
+          if deployment is None:
+              lines.extend([
+                  '- OIDC deployment workflow run: **not registered during observer window**',
+                  f'- API error: `{api_error or "none"}`',
+                  '- Interpretation: the deployment trigger or workflow registration failed; no cloud restoration can be credited.',
+              ])
+          else:
+              lines.extend([
+                  f'- Workflow run: **#{deployment.get("run_number")}** (`{deployment.get("id")}`)',
+                  f'- Workflow status: **{deployment.get("status") or "unknown"}**',
+                  f'- Workflow conclusion: **{deployment.get("conclusion") or "none"}**',
+                  f'- Run URL: {deployment.get("html_url") or ""}',
+              ])
+
+              if skip_step and skip_step.get('conclusion') == 'success':
+                  lines.append('- Deployment path: **skipped by preflight**. The repository deployment variable or WIF prerequisites are absent.')
+              elif submit_step and submit_step.get('conclusion') == 'success':
+                  lines.append('- Cloud Build submission: **success**')
+                  lines.append(
+                      f'- Post-deploy verifier: **{(verify_step or {}).get("conclusion") or "not completed"}**'
+                  )
+              elif deployment.get('status') == 'completed' and deployment.get('conclusion') != 'success':
+                  failing = [
+                      f"{item['job']} / {item['name']}"
+                      for item in steps
+                      if item.get('conclusion') == 'failure'
+                  ]
+                  lines.append(
+                      '- Failing step(s): ' + (', '.join(failing) if failing else 'not exposed by jobs API')
+                  )
+              else:
+                  lines.append('- Deployment path: registered but not completed during the observer window.')
+
+          lines.extend(['', '### Public route proof'])
+          for item in route_results:
+              lines.append(
+                  f"- `{item['path']}`: HTTP `{item['status']}` · cache `{item['cache_control'] or 'none'}`"
+              )
+          lines.extend([
+              f'- Runtime release SHA: `{release_sha or "absent"}`',
+              f'- Expected release SHA: `{head_sha}`',
+              f'- Receipt verdict: **{"PASS" if public_pass else "FAIL"}**',
+          ])
+
+          if public_pass:
+              lines.append('Interpretation: the public runtime is restored and receipt-backed for this exact commit.')
+          elif routes_green and not release_matches:
+              lines.append('Interpretation: a runtime is online, but it is not proved to be the triggering release.')
+          else:
+              lines.append('Interpretation: the public-demo gate remains red; no live claim is justified.')
+
+          body = '\n'.join(lines)
+          request_json(
+              f'{api_base}/issues/{issue_number}/comments',
+              method='POST',
+              payload={'body': body},
+          )
+          print(body)
+          PY


### PR DESCRIPTION
## Purpose

Make the public-demo restoration path observable from GitHub without cloud-console access.

## Behavior

- runs on GitHub-hosted Ubuntu after this workflow is merged to `main`;
- reads only the Actions runs/jobs APIs and the three public demo routes;
- correlates the OIDC deployment run to the same commit SHA;
- distinguishes a missing run, preflight skip, active deployment, Cloud Build success, verifier failure, and completed success;
- directly probes `/demo`, `/health`, and `/status`;
- requires HTTP 200, `no-store` receipts, and exact release-SHA equality for PASS;
- posts a bounded result to issue #180;
- reads no WIF secret, access token, cloud resource configuration, or private runtime data;
- performs no cloud mutation.

This observer does not make the demo green. It prevents a skipped or stale deployment from being mistaken for green.