### PR TITLE
ops(demo): restore the public Cloud Run runtime

### DIFF
--- a/ops/public-demo-restoration-2026-07-31.md
+++ b/ops/public-demo-restoration-2026-07-31.md
@@ -1,0 +1,25 @@
+# Public demo restoration — 2026-07-31
+
+## Incident
+
+The Fractal5 `/demo-1` bridge currently advertises the public Google Cloud Run sandbox, while the canonical public runtime routes return HTTP 404:
+
+- `/demo`
+- `/health`
+- `/status`
+
+The source repository remains healthy and contains the expected Flask routes, production Docker entrypoint, OIDC deployment workflow, exact-release verification, security headers, no-store public receipts, and public-safe boundary controls.
+
+## Authorized action
+
+Merge of this documentation-only operational trigger is authorized to invoke the existing `Build & Deploy Public Demo (OIDC)` workflow on `main` and restore the canonical `demo` Cloud Run service in `us-central1` from the exact merged commit.
+
+## Required proof
+
+The deployment is complete only when the workflow proves all three routes return HTTP 200, `/health` and `/status` are JSON with `Cache-Control: no-store`, the public demo copy is claim-safe, and `releaseCandidateSha` equals the merged commit SHA.
+
+## Boundaries
+
+- No customer, payment, private source, secret, or production data is exposed.
+- No new paid architecture is created; the existing scale-to-zero public demo service is reused.
+- The deployment may not be described as successful from a build alone. The live route receipt is decisive.


### PR DESCRIPTION
## Purpose

Restore the canonical public demo service now that `/demo`, `/health`, and `/status` are returning HTTP 404 while the Squarespace `/demo-1` bridge still presents them as live.

## Change

Adds a permanent operational receipt authorizing the existing OIDC deployment workflow to redeploy the current, already-reviewed `main` source. No runtime code, dependency, secret, IAM, billing, or public copy change is introduced by this PR.

## Merge effect

A push to `main` invokes `Build & Deploy Public Demo (OIDC)`, which builds the production image, deploys Cloud Run service `demo` in `us-central1`, and fails unless the exact merged SHA is returned by the live `/health` or `/status` receipt and all three public routes pass.

## Safety

- existing scale-to-zero service only;
- no customer or private data;
- no new architecture;
- live HTTP receipt, not build completion, decides success.