### PR TITLE
feat(proof): make public-demo green exact-release and self-closing

### DIFF
--- a/.github/workflows/public-demo-release-proof.yml
+++ b/.github/workflows/public-demo-release-proof.yml
@@ -1,0 +1,277 @@
+name: Public demo exact-release proof
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/cicd-deploy.yml'
+      - '.github/workflows/public-demo-release-proof.yml'
+      - 'cloudbuild.yaml'
+      - 'Dockerfile.production'
+      - 'app.py'
+      - 'server.py'
+      - 'ops/public-demo-restoration-*.md'
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: public-demo-release-proof-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  prove:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Correlate deployment and prove public routes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          HEAD_SHA: ${{ github.sha }}
+          ISSUE_NUMBER: '180'
+          DEPLOY_WORKFLOW: cicd-deploy.yml
+          PUBLIC_BASE_URL: https://demo-reduwyf2ra-uc.a.run.app
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import time
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          token = os.environ['GH_TOKEN']
+          repository = os.environ['REPOSITORY']
+          head_sha = os.environ['HEAD_SHA']
+          issue_number = os.environ['ISSUE_NUMBER']
+          workflow = os.environ['DEPLOY_WORKFLOW']
+          public_base = os.environ['PUBLIC_BASE_URL'].rstrip('/')
+          api_base = f'https://api.github.com/repos/{repository}'
+          headers = {
+              'Authorization': f'Bearer {token}',
+              'Accept': 'application/vnd.github+json',
+              'X-GitHub-Api-Version': '2022-11-28',
+              'User-Agent': 'fractal5-public-demo-release-proof/1.0',
+          }
+
+          def api(path, method='GET', payload=None):
+              data = None
+              request_headers = dict(headers)
+              if payload is not None:
+                  data = json.dumps(payload).encode('utf-8')
+                  request_headers['Content-Type'] = 'application/json'
+              request = urllib.request.Request(
+                  api_base + path,
+                  data=data,
+                  method=method,
+                  headers=request_headers,
+              )
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  body = response.read().decode('utf-8')
+                  return json.loads(body) if body else {}
+
+          query = urllib.parse.urlencode({
+              'branch': 'main',
+              'event': 'push',
+              'per_page': '50',
+          })
+          deployment = None
+          jobs = []
+          api_error = None
+          for _ in range(240):
+              try:
+                  runs = api(f'/actions/workflows/{workflow}/runs?{query}')
+                  deployment = next(
+                      (
+                          run for run in runs.get('workflow_runs', [])
+                          if run.get('head_sha') == head_sha
+                      ),
+                      None,
+                  )
+                  if deployment:
+                      jobs = api(
+                          f"/actions/runs/{deployment['id']}/jobs?per_page=100"
+                      ).get('jobs', [])
+                      if deployment.get('status') == 'completed':
+                          break
+              except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as exc:
+                  api_error = str(exc)
+              time.sleep(5)
+
+          route_results = []
+          health = {}
+          status_receipt = {}
+          route_error = None
+          for _ in range(30):
+              current = []
+              parsed = {}
+              try:
+                  for path in ('/demo', '/health', '/status'):
+                      request = urllib.request.Request(
+                          public_base + path,
+                          headers={
+                              'User-Agent': 'fractal5-public-demo-release-proof/1.0'
+                          },
+                      )
+                      with urllib.request.urlopen(request, timeout=25) as response:
+                          body = response.read(1_000_000).decode(
+                              'utf-8', errors='replace'
+                          )
+                          current.append({
+                              'path': path,
+                              'status': response.status,
+                              'contentType': response.headers.get('content-type', ''),
+                              'cacheControl': response.headers.get('cache-control', ''),
+                              'body': body,
+                          })
+                          if path in ('/health', '/status'):
+                              parsed[path] = json.loads(body)
+                  route_results = current
+                  health = parsed.get('/health', {})
+                  status_receipt = parsed.get('/status', {})
+                  release_sha = (
+                      health.get('releaseCandidateSha')
+                      or status_receipt.get('releaseCandidateSha')
+                      or health.get('release_sha')
+                      or status_receipt.get('release_sha')
+                      or ''
+                  )
+                  if (
+                      all(item['status'] == 200 for item in current)
+                      and release_sha == head_sha
+                  ):
+                      break
+              except (
+                  urllib.error.HTTPError,
+                  urllib.error.URLError,
+                  TimeoutError,
+                  json.JSONDecodeError,
+              ) as exc:
+                  route_error = str(exc)
+              time.sleep(10)
+
+          release_sha = (
+              health.get('releaseCandidateSha')
+              or status_receipt.get('releaseCandidateSha')
+              or health.get('release_sha')
+              or status_receipt.get('release_sha')
+              or ''
+          )
+          routes_green = len(route_results) == 3 and all(
+              item.get('status') == 200 for item in route_results
+          )
+          receipts_json = all(
+              'application/json' in item.get('contentType', '').lower()
+              for item in route_results
+              if item.get('path') in ('/health', '/status')
+          )
+          no_store = all(
+              'no-store' in item.get('cacheControl', '').lower()
+              for item in route_results
+              if item.get('path') in ('/health', '/status')
+          )
+          demo_body = next(
+              (item.get('body', '').lower() for item in route_results if item.get('path') == '/demo'),
+              '',
+          )
+          forbidden = (
+              'actual demo mp4 integrated',
+              'open web mp4',
+              'open master mp4',
+              'mp4 integrated',
+          )
+          claim_safe = bool(demo_body) and not any(
+              marker in demo_body for marker in forbidden
+          )
+          release_matches = release_sha == head_sha
+          deployment_success = bool(
+              deployment
+              and deployment.get('status') == 'completed'
+              and deployment.get('conclusion') == 'success'
+          )
+          public_pass = (
+              deployment_success
+              and routes_green
+              and receipts_json
+              and no_store
+              and claim_safe
+              and release_matches
+          )
+
+          failed_steps = []
+          for job in jobs:
+              for step in job.get('steps', []) or []:
+                  if step.get('conclusion') == 'failure':
+                      failed_steps.append(
+                          f"{job.get('name', 'job')} / {step.get('name', 'step')}"
+                      )
+
+          lines = [
+              '## Exact-release public demo proof',
+              '',
+              f'- Commit: `{head_sha}`',
+          ]
+          if deployment:
+              lines.extend([
+                  f"- Deployment run: `{deployment.get('id')}`",
+                  f"- Deployment status: **{deployment.get('status') or 'unknown'}**",
+                  f"- Deployment conclusion: **{deployment.get('conclusion') or 'none'}**",
+                  f"- Deployment URL: {deployment.get('html_url') or ''}",
+              ])
+          else:
+              lines.extend([
+                  '- Deployment run: **not found**',
+                  f"- API error: `{api_error or 'none'}`",
+              ])
+          if failed_steps:
+              lines.append('- Failed step(s): ' + ', '.join(failed_steps))
+
+          lines.extend(['', '### Route evidence'])
+          if route_results:
+              for item in route_results:
+                  lines.append(
+                      f"- `{item['path']}`: HTTP `{item['status']}`; "
+                      f"content `{item['contentType'] or 'none'}`; "
+                      f"cache `{item['cacheControl'] or 'none'}`"
+                  )
+          else:
+              lines.append(f'- Routes unavailable: `{route_error or "unknown"}`')
+
+          lines.extend([
+              f'- Runtime release SHA: `{release_sha or "absent"}`',
+              f'- JSON receipts: **{receipts_json}**',
+              f'- No-store receipts: **{no_store}**',
+              f'- Claim-safe demo: **{claim_safe}**',
+              f'- Exact-release match: **{release_matches}**',
+              f'- Final verdict: **{"PASS" if public_pass else "FAIL"}**',
+          ])
+          if public_pass:
+              lines.append(
+                  'Interpretation: the public demo is live, public-safe, and receipt-backed for this exact release.'
+              )
+          else:
+              lines.append(
+                  'Interpretation: the public-demo gate remains closed; no green claim is justified.'
+              )
+
+          api(
+              f'/issues/{issue_number}/comments',
+              method='POST',
+              payload={'body': '\n'.join(lines)},
+          )
+          if public_pass:
+              api(
+                  f'/issues/{issue_number}',
+                  method='PATCH',
+                  payload={'state': 'closed', 'state_reason': 'completed'},
+              )
+
+          print('\n'.join(lines))
+          if not public_pass:
+              raise SystemExit(1)
+          PY


### PR DESCRIPTION
## Purpose

Make public-demo readiness a permanent exact-release fact, not a manual impression.

## Control

For demo-affecting commits on `main`, this workflow:

- correlates the `cicd-deploy.yml` push run to the exact commit SHA;
- waits for the deployment to reach a terminal state;
- probes `/demo`, `/health`, and `/status`;
- requires HTTP 200 on all routes;
- requires JSON and `Cache-Control: no-store` on health/status;
- rejects forbidden unsupported demo claims;
- requires the runtime receipt SHA to equal the triggering commit;
- posts the full proof to incident #180;
- closes #180 only on PASS;
- fails closed otherwise.

## Cost and safety

The proof runs only for deployment-relevant paths, uses standard-library HTTP calls, has read-only repository/action permissions plus issue-comment authority, exposes no credentials or private data, and creates no infrastructure.