### PR TITLE
fix(deploy): withhold public deployment until Google trust root exists

### DIFF
--- a/.github/workflows/cicd-deploy.yml
+++ b/.github/workflows/cicd-deploy.yml
@@ -19,12 +19,13 @@ jobs:
   build-deploy:
     runs-on: ubuntu-latest
     env:
-      # These are public resource identifiers, not credentials. Repository
-      # variables may override them; legacy secret locations remain compatible.
-      DEPLOY_ENABLED: ${{ vars.ENABLE_OIDC_DEPLOY || 'true' }}
+      # Project and identity resource names are identifiers, not credentials.
+      # Deployment remains withheld until an operator restores the Google trust
+      # root and explicitly enables this repository through variables.
+      DEPLOY_ENABLED: ${{ vars.ENABLE_OIDC_DEPLOY || 'false' }}
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID || secrets.GCP_PROJECT_ID || 'f5-prod-command-core' }}
-      WIF_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER || secrets.GCP_WORKLOAD_IDENTITY_PROVIDER || secrets.GCP_WIF_PROVIDER || 'projects/732190342674/locations/global/workloadIdentityPools/fractal5-github-pool/providers/github-provider' }}
-      WIF_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL || secrets.GCP_SERVICE_ACCOUNT_EMAIL || secrets.GCP_WIF_SA_EMAIL || 'dominion-demo-oidc-sa@f5-prod-command-core.iam.gserviceaccount.com' }}
+      WIF_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER || secrets.GCP_WORKLOAD_IDENTITY_PROVIDER || secrets.GCP_WIF_PROVIDER || '' }}
+      WIF_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL || secrets.GCP_SERVICE_ACCOUNT_EMAIL || secrets.GCP_WIF_SA_EMAIL || '' }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
@@ -37,7 +38,7 @@ jobs:
           set -euo pipefail
           missing=()
           if [ "${DEPLOY_ENABLED}" != "true" ]; then
-            missing+=("ENABLE_OIDC_DEPLOY is explicitly disabled")
+            missing+=("ENABLE_OIDC_DEPLOY is not true")
           fi
           if [ -z "${WIF_PROVIDER}" ]; then
             missing+=("GCP_WORKLOAD_IDENTITY_PROVIDER/GCP_WIF_PROVIDER")
@@ -58,8 +59,44 @@ jobs:
           fi
 
           echo "project=${GCP_PROJECT_ID}"
-          echo "provider=${WIF_PROVIDER##*/}"
-          echo "service_account_domain=${WIF_SERVICE_ACCOUNT#*@}"
+          if [ -n "${WIF_PROVIDER}" ]; then
+            echo "provider=${WIF_PROVIDER##*/}"
+          else
+            echo "provider=absent"
+          fi
+          if [ -n "${WIF_SERVICE_ACCOUNT}" ]; then
+            echo "service_account_domain=${WIF_SERVICE_ACCOUNT#*@}"
+          else
+            echo "service_account_domain=absent"
+          fi
+
+      - name: Write withheld receipt
+        if: steps.preflight.outputs.ready != 'true'
+        env:
+          MISSING_CONTROLS: ${{ steps.preflight.outputs.missing }}
+        run: |
+          set -euo pipefail
+          mkdir -p out/deploy-receipt
+          python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+
+          receipt = {
+              "schema": "f5.public-demo.deploy-receipt.v1",
+              "generatedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+              "expectedSha": os.environ["GITHUB_SHA"],
+              "projectId": os.environ.get("GCP_PROJECT_ID", ""),
+              "state": "WITHHELD",
+              "pass": False,
+              "reason": os.environ.get("MISSING_CONTROLS", "deployment prerequisites absent"),
+              "certificationRule": "A withheld or missing deployment is never public-demo GREEN.",
+          }
+          with open("out/deploy-receipt/public-demo-deploy.json", "w", encoding="utf-8") as handle:
+              json.dump(receipt, handle, indent=2)
+              handle.write("\n")
+          print(json.dumps(receipt, indent=2))
+          PY
 
       - name: Authenticate to Google Cloud
         if: steps.preflight.outputs.ready == 'true'
@@ -115,26 +152,44 @@ jobs:
               results = []
               try:
                   for path in paths:
-                      req = urllib.request.Request(base + path, headers={"User-Agent": "fractal5-deploy-verifier/1.0"})
-                      with urllib.request.urlopen(req, timeout=20) as res:
-                          body = res.read().decode("utf-8", errors="replace")
+                      request = urllib.request.Request(
+                          base + path,
+                          headers={"User-Agent": "fractal5-deploy-verifier/1.0"},
+                      )
+                      with urllib.request.urlopen(request, timeout=20) as response:
+                          body = response.read().decode("utf-8", errors="replace")
                           results.append({
                               "path": path,
-                              "status": res.status,
-                              "contentType": res.headers.get("content-type", ""),
-                              "cacheControl": res.headers.get("cache-control", ""),
+                              "status": response.status,
+                              "contentType": response.headers.get("content-type", ""),
+                              "cacheControl": response.headers.get("cache-control", ""),
                               "body": body,
                           })
 
-                  health = json.loads(next(r["body"] for r in results if r["path"] == "/health"))
-                  status = json.loads(next(r["body"] for r in results if r["path"] == "/status"))
-                  demo_body = next(r["body"] for r in results if r["path"] == "/demo").lower()
-                  forbidden = ["actual demo mp4 integrated", "open web mp4", "open master mp4", "mp4 integrated"]
+                  health = json.loads(next(item["body"] for item in results if item["path"] == "/health"))
+                  status = json.loads(next(item["body"] for item in results if item["path"] == "/status"))
+                  demo_body = next(item["body"] for item in results if item["path"] == "/demo").lower()
+                  forbidden = [
+                      "actual demo mp4 integrated",
+                      "open web mp4",
+                      "open master mp4",
+                      "mp4 integrated",
+                  ]
                   claim_safe = not any(text in demo_body for text in forbidden)
                   revision = health.get("revision") or status.get("revision") or ""
-                  release_sha = health.get("releaseCandidateSha") or status.get("releaseCandidateSha") or health.get("release_sha") or status.get("release_sha") or ""
-                  fresh = all((r["status"] == 200 for r in results))
-                  no_store = all("no-store" in r["cacheControl"].lower() for r in results if r["path"] in ("/health", "/status"))
+                  release_sha = (
+                      health.get("releaseCandidateSha")
+                      or status.get("releaseCandidateSha")
+                      or health.get("release_sha")
+                      or status.get("release_sha")
+                      or ""
+                  )
+                  fresh = all(item["status"] == 200 for item in results)
+                  no_store = all(
+                      "no-store" in item["cacheControl"].lower()
+                      for item in results
+                      if item["path"] in ("/health", "/status")
+                  )
 
                   receipt = {
                       "schema": "f5.public-demo.deploy-receipt.v1",
@@ -142,7 +197,10 @@ jobs:
                       "expectedSha": expected_sha,
                       "revision": revision,
                       "releaseSha": release_sha,
-                      "routes": [{k: v for k, v in r.items() if k != "body"} for r in results],
+                      "routes": [
+                          {key: value for key, value in item.items() if key != "body"}
+                          for item in results
+                      ],
                       "claimSafe": claim_safe,
                       "noStore": no_store,
                       "pass": fresh and claim_safe and no_store and release_sha == expected_sha,
@@ -160,16 +218,44 @@ jobs:
                   }
               time.sleep(delay)
 
-          with open("out/deploy-receipt/public-demo-deploy.json", "w", encoding="utf-8") as fh:
-              json.dump(last, fh, indent=2)
-              fh.write("\n")
+          with open("out/deploy-receipt/public-demo-deploy.json", "w", encoding="utf-8") as handle:
+              json.dump(last, handle, indent=2)
+              handle.write("\n")
           print(json.dumps(last, indent=2))
           if not last or not last.get("pass"):
               raise SystemExit(1)
           PY
 
+      - name: Write failed pre-verification receipt
+        if: failure() && steps.preflight.outputs.ready == 'true'
+        run: |
+          set -euo pipefail
+          if [ -f out/deploy-receipt/public-demo-deploy.json ]; then
+            exit 0
+          fi
+          mkdir -p out/deploy-receipt
+          python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+
+          receipt = {
+              "schema": "f5.public-demo.deploy-receipt.v1",
+              "generatedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+              "expectedSha": os.environ["GITHUB_SHA"],
+              "projectId": os.environ.get("GCP_PROJECT_ID", ""),
+              "state": "FAILED_BEFORE_PUBLIC_VERIFICATION",
+              "pass": False,
+              "certificationRule": "Authentication or build failure is never public-demo GREEN.",
+          }
+          with open("out/deploy-receipt/public-demo-deploy.json", "w", encoding="utf-8") as handle:
+              json.dump(receipt, handle, indent=2)
+              handle.write("\n")
+          print(json.dumps(receipt, indent=2))
+          PY
+
       - name: Upload deployment receipt
-        if: always() && steps.preflight.outputs.ready == 'true'
+        if: always() && hashFiles('out/deploy-receipt/public-demo-deploy.json') != ''
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: public-demo-deploy-receipt
@@ -180,4 +266,4 @@ jobs:
       - name: Skip summary
         if: steps.preflight.outputs.ready != 'true'
         run: |
-          echo "Skipping OIDC deploy. Missing prerequisites: ${{ steps.preflight.outputs.missing }}"
+          echo "OIDC deployment withheld. Missing prerequisites: ${{ steps.preflight.outputs.missing }}"


### PR DESCRIPTION
## Purpose

Return the deployment lane to an honest fail-safe posture after exact proof established that both presumed Google Workload Identity providers are absent, disabled, or deleted.

## Change

- deployment defaults to disabled unless `ENABLE_OIDC_DEPLOY=true` is explicitly configured;
- project ID remains a governed identifier, while WIF provider and service-account identifiers must be supplied from approved repository configuration;
- missing prerequisites produce an uploaded machine-readable `WITHHELD` receipt instead of silent optimism;
- authentication/build failures produce a failure receipt when possible;
- artifact upload no longer creates a second false failure when no receipt file exists;
- all credential handling remains keyless and no long-lived credential fallback is introduced.

## Truth state

This PR does not restore the runtime. It prevents every future `main` push from repeatedly attempting a known-nonexistent federation and records the external trust-root blocker precisely.

## Safety

No cloud mutation, IAM mutation, billing action, credential value, customer data, or public claim is included.