### PR TITLE
feat(pages): publish a zero-secret public-safe Dominion demo

### DIFF
--- a/.github/workflows/public-static-demo-pages.yml
+++ b/.github/workflows/public-static-demo-pages.yml
@@ -1,0 +1,226 @@
+name: Publish public-safe static Dominion demo
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/public-static-demo-pages.yml'
+      - 'squarespace/demo-1-final.html'
+      - 'demo/assets/demo-manifest.json'
+      - 'demo/assets/cloud-deployment-manifest.json'
+      - 'demo/assets/sample-data.json'
+      - 'demo/assets/demo-download-package.json'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  issues: write
+
+concurrency:
+  group: public-static-demo-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Build public-safe static site
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf _site
+          mkdir -p _site
+          python3 - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          source = Path('squarespace/demo-1-final.html').read_text(encoding='utf-8')
+          required = [
+              'MULTI-CLOUD DEPLOYMENT READY',
+              'Dominion OS is ready for your cloud.',
+              'Public sandbox availability is a separate demonstration service',
+          ]
+          forbidden = [
+              'LIVE GOOGLE CLOUD DEMO',
+              'Dominion OS, live on the cloud.',
+              'Send this page to prospects who need to see Dominion OS in operation.',
+          ]
+          for marker in required:
+              if marker not in source:
+                  raise SystemExit(f'missing required public-safe marker: {marker}')
+          for marker in forbidden:
+              if marker in source:
+                  raise SystemExit(f'stale live-runtime claim detected: {marker}')
+
+          head_sha = os.environ['GITHUB_SHA']
+          generated_at = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+          banner = '''
+          <div role="status" style="max-width:1200px;margin:18px auto 0;padding:14px 20px;border:1px solid #e4ded3;border-radius:14px;background:#fbfaf7;color:#2a2b2e;font:600 13px/1.55 Manrope,system-ui,-apple-system,Segoe UI,sans-serif">
+            Public deployment demonstration · Static, public-safe proof surface. Client deployments are scoped and executed under governed provider contracts. The optional Google Cloud Run sandbox is not represented as live here.
+          </div>
+          '''
+          document = f'''<!doctype html>
+          <html lang="en-CA">
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width,initial-scale=1">
+            <meta name="description" content="Dominion OS™ + SaaS Suite multi-cloud deployment demonstration from Fractal5 Solutions.">
+            <meta name="robots" content="index,follow">
+            <meta name="referrer" content="strict-origin-when-cross-origin">
+            <title>Dominion OS™ Multi-Cloud Deployment Demo | Fractal5 Solutions</title>
+          </head>
+          <body style="margin:0;background:#fff">
+          {banner}
+          {source}
+          </body>
+          </html>
+          '''
+          Path('_site/index.html').write_text(document, encoding='utf-8', newline='\n')
+          Path('_site/404.html').write_text(document, encoding='utf-8', newline='\n')
+          Path('_site/.nojekyll').write_text('', encoding='utf-8')
+          receipt = {
+              'schema': 'f5.public-static-demo.release.v1',
+              'generatedAt': generated_at,
+              'releaseSha': head_sha,
+              'mode': 'static-public-safe-deployment-demonstration',
+              'cloudRunSandboxClaimedLive': False,
+              'source': 'squarespace/demo-1-final.html',
+              'pass': True,
+              'certificationRule': (
+                  'PASS means the static public-safe deployment demonstration was built '
+                  'from the reviewed canonical source at this exact commit. It does not '
+                  'certify a live Cloud Run sandbox or a client production deployment.'
+              ),
+          }
+          Path('_site/release.json').write_text(
+              json.dumps(receipt, indent=2) + '\n',
+              encoding='utf-8',
+              newline='\n',
+          )
+          print(json.dumps(receipt, indent=2))
+          PY
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          path: _site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+
+      - name: Verify exact public static release
+        env:
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+          HEAD_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          ISSUE_NUMBER: '180'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import time
+          import urllib.error
+          import urllib.request
+
+          page_url = os.environ['PAGE_URL'].rstrip('/') + '/'
+          release_url = page_url + 'release.json'
+          expected_sha = os.environ['HEAD_SHA']
+          last_error = None
+          html = ''
+          receipt = {}
+          for _ in range(30):
+              try:
+                  request = urllib.request.Request(
+                      page_url,
+                      headers={'User-Agent': 'fractal5-static-demo-verifier/1.0'},
+                  )
+                  with urllib.request.urlopen(request, timeout=20) as response:
+                      if response.status != 200:
+                          raise RuntimeError(f'page HTTP {response.status}')
+                      html = response.read(2_000_000).decode('utf-8', errors='replace')
+                  request = urllib.request.Request(
+                      release_url,
+                      headers={'User-Agent': 'fractal5-static-demo-verifier/1.0'},
+                  )
+                  with urllib.request.urlopen(request, timeout=20) as response:
+                      if response.status != 200:
+                          raise RuntimeError(f'release HTTP {response.status}')
+                      receipt = json.loads(response.read().decode('utf-8'))
+                  if receipt.get('releaseSha') == expected_sha:
+                      break
+              except Exception as exc:
+                  last_error = str(exc)
+              time.sleep(10)
+
+          required = [
+              'MULTI-CLOUD DEPLOYMENT READY',
+              'Static, public-safe proof surface',
+              'The optional Google Cloud Run sandbox is not represented as live here.',
+          ]
+          forbidden = [
+              'LIVE GOOGLE CLOUD DEMO',
+              'Dominion OS, live on the cloud.',
+          ]
+          passed = (
+              bool(html)
+              and all(marker in html for marker in required)
+              and not any(marker in html for marker in forbidden)
+              and receipt.get('pass') is True
+              and receipt.get('releaseSha') == expected_sha
+              and receipt.get('cloudRunSandboxClaimedLive') is False
+          )
+          body = '\n'.join([
+              '## Public static demo proof',
+              '',
+              f'- Exact commit: `{expected_sha}`',
+              f'- Page URL: {page_url}',
+              f'- Release receipt: {release_url}',
+              f'- Static public-safe marker: **{all(marker in html for marker in required)}**',
+              f'- Stale live-runtime claims absent: **{not any(marker in html for marker in forbidden)}**',
+              f'- Exact-release receipt: **{receipt.get("releaseSha") == expected_sha}**',
+              f'- Final static-demo verdict: **{"PASS" if passed else "FAIL"}**',
+              '',
+              'This proves a public, shareable, static deployment demonstration. It does not close the separate Cloud Run runtime incident.',
+          ])
+          api = f"https://api.github.com/repos/{os.environ['REPOSITORY']}/issues/{os.environ['ISSUE_NUMBER']}/comments"
+          request = urllib.request.Request(
+              api,
+              data=json.dumps({'body': body}).encode('utf-8'),
+              method='POST',
+              headers={
+                  'Authorization': f"Bearer {os.environ['GH_TOKEN']}",
+                  'Accept': 'application/vnd.github+json',
+                  'Content-Type': 'application/json',
+                  'X-GitHub-Api-Version': '2022-11-28',
+                  'User-Agent': 'fractal5-static-demo-verifier/1.0',
+              },
+          )
+          with urllib.request.urlopen(request, timeout=30):
+              pass
+          print(body)
+          if not passed:
+              raise SystemExit(last_error or 'static public demo verification failed')
+          PY


### PR DESCRIPTION
## Purpose

Publish the reviewed multi-cloud deployment demonstration through GitHub Pages as a zero-secret, public-safe fallback while the separate Google Cloud Run trust root remains unavailable.

## Public surface

The workflow builds from `squarespace/demo-1-final.html`, wraps it as a standalone indexed page, and publishes an exact-release `release.json` receipt. It requires the reviewed multi-cloud readiness markers and rejects the stale “LIVE GOOGLE CLOUD DEMO” and “Dominion OS, live on the cloud” copy.

After deployment it verifies:

- the page is HTTP 200;
- the public-safe static banner is present;
- stale live-runtime claims are absent;
- the release receipt matches the exact commit;
- the receipt explicitly states that the Cloud Run sandbox is not claimed live.

The result is posted to incident #180. A successful static publication does not close that separate runtime incident.

## Safety and cost

- public repository and GitHub-native Pages only;
- no cloud credential, secret, customer data, IAM mutation, billing mutation, or private code;
- all third-party actions are pinned to immutable SHAs;
- no claim that the static surface is a live backend or production client deployment.