### PR TITLE
build(security): consolidate current-main patch updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload Trivy results to GitHub Security
         if: ${{ hashFiles('trivy-results.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: 'trivy-results.sarif'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,14 +11,14 @@ requests>=2.33.0
 google-cloud-core>=2.3.3
 google-cloud-storage>=2.10.0
 google-cloud-secret-manager>=2.16.4
-google-auth>=2.51.0
+google-auth>=2.56.2
 google-api-python-client>=2.97.0
 
 # Docker & Containerization
 docker>=7.1.0
 
 # YAML Processing
-PyYAML>=6.0.1
+PyYAML>=6.0.3
 
 # Data Processing
 pandas>=2.0.3


### PR DESCRIPTION
Certification program: Fractal5-Solutions/dominion-command-center#709
Repository gate: Fractal5-Solutions/dominion-command-center#710
Supersedes stale patch branches #168, #173 and #175 after merge.

## Changes
- update the SHA-pinned CodeQL SARIF uploader from v4.35.3 to v4.37.3;
- raise the PyYAML minimum from 6.0.1 to 6.0.3;
- raise the google-auth minimum from 2.51.0 to 2.56.2.

## Construction
Rebuilt directly on current `main` after the certified TruffleHog merge. No stale Dependabot history is merged.

## Acceptance
Merge only if CI, Security Scan, Secret Scan, dependency review, governance and Canon Φ pass on exact head `3962cf4807064f9b48b5bbc04695a18e1c81af84`, with no unresolved review thread.