### PR TITLE
feat(signal): integrate Conversations for a Country Worth Building

### DIFF
--- a/.github/scripts/proof_bluewave_signal.py
+++ b/.github/scripts/proof_bluewave_signal.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+HTML_PATH = Path("web/bluewave/signal.code.html")
+CONFIG_PATH = Path("web/bluewave/signal.config.json")
+OUT_PATH = Path("bluewave_signal_manifest.json")
+
+APPROVED_IMAGE_URL = (
+    "https://images.squarespace-cdn.com/content/67705dbf69e06a2e83e53c93/"
+    "516a7db9-586f-416f-bcc2-fe834daf10eb/"
+    "Conversations+for+a+Country+Worth+Building.png?content-type=image%2Fpng"
+)
+
+REQUIRED_HTML = [
+    'id="bw-signal"',
+    'data-version="signal-squarespace-v2"',
+    'id="conversations"',
+    "Conversations for a Country Worth Building",
+    "One guest. One serious question. Thirty minutes.",
+    APPROVED_IMAGE_URL,
+    'aspect-ratio:16/9',
+    'object-fit:contain',
+    'alt="BlueWave Signal — Conversations for a Country Worth Building, connecting Ottawa and Vancouver."',
+    'id="flagship-show"',
+    "Guest announcements come after consent—not before.",
+    "episode_status:\"in_development\"",
+]
+
+FORBIDDEN_TEXT = [
+    "Patrick Hunt",
+    "Maldwyn Thomas",
+    "api_key",
+    "api-key",
+    "service account",
+    "password",
+    "private endpoint",
+    "admin dashboard",
+]
+
+
+def fail(message: str, errors: list[str]) -> None:
+    errors.append(message)
+
+
+def main() -> int:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if not HTML_PATH.exists():
+        fail(f"missing {HTML_PATH}", errors)
+    if not CONFIG_PATH.exists():
+        fail(f"missing {CONFIG_PATH}", errors)
+    if errors:
+        return write_result(errors, warnings)
+
+    html = HTML_PATH.read_text(encoding="utf-8")
+    config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+
+    for snippet in REQUIRED_HTML:
+        if snippet not in html:
+            fail(f"required HTML snippet missing: {snippet}", errors)
+
+    for text in FORBIDDEN_TEXT:
+        if text.lower() in html.lower():
+            fail(f"forbidden public text present: {text}", errors)
+
+    if html.count('id="bw-signal"') != 1:
+        fail("#bw-signal root must occur exactly once", errors)
+    if re.search(r"<main\b", html, flags=re.IGNORECASE):
+        fail("nested <main> is forbidden in Squarespace payload", errors)
+    if re.search(r"<script[^>]+src=", html, flags=re.IGNORECASE):
+        fail("external JavaScript is forbidden", errors)
+    if re.search(r"<link[^>]+rel=[\"']stylesheet", html, flags=re.IGNORECASE):
+        fail("external stylesheets are forbidden", errors)
+
+    hero_index = html.find('class="hero"')
+    conversations_index = html.find('id="conversations"')
+    flagship_index = html.find('id="flagship-show"')
+    if not (0 <= hero_index < conversations_index < flagship_index):
+        fail("conversation module must appear after hero and before flagship-show", errors)
+
+    hrefs = re.findall(r'href="([^"]+)"', html)
+    for href in hrefs:
+        parsed = urlparse(href)
+        if parsed.scheme or parsed.netloc:
+            fail(f"external href is not permitted before approval: {href}", errors)
+        if not (href.startswith("/") or href.startswith("#")):
+            fail(f"href must be relative or fragment-only: {href}", errors)
+
+    image_sources = re.findall(r'<img[^>]+src="([^"]+)"', html, flags=re.IGNORECASE)
+    if image_sources != [APPROVED_IMAGE_URL]:
+        fail("the only image source must be the approved conversation graphic", errors)
+
+    expected_config = {
+        "page": "/signal",
+        "brand": "BlueWave Action Group",
+        "version": "signal-squarespace-v2",
+        "mode": "public_prelaunch",
+        "primaryPlatform": "Substack",
+        "contentModel": "conversations_plus_writing",
+    }
+    for key, expected in expected_config.items():
+        if config.get(key) != expected:
+            fail(f"config {key!r} must equal {expected!r}", errors)
+
+    series = config.get("series", {})
+    if series.get("tagline") != "Conversations for a Country Worth Building":
+        fail("series tagline mismatch", errors)
+    if series.get("status") != "in_development":
+        fail("series status must be in_development", errors)
+    if series.get("imageUrl") != APPROVED_IMAGE_URL:
+        fail("series imageUrl mismatch", errors)
+    if series.get("imageAspectRatio") != "16:9" or series.get("imageCrop") != "none":
+        fail("series image must remain uncropped at 16:9", errors)
+
+    safety = config.get("safety", {})
+    required_safety = {
+        "publicOnly": True,
+        "privateCommandAllowed": False,
+        "guestNeutralUntilConfirmed": True,
+        "requiresWrittenAcceptance": True,
+        "requiresPublicationPermission": True,
+    }
+    for key, expected in required_safety.items():
+        if safety.get(key) is not expected:
+            fail(f"safety {key!r} must equal {expected!r}", errors)
+
+    forbidden_guest_names = safety.get("forbiddenGuestNames", [])
+    if sorted(forbidden_guest_names) != ["Maldwyn Thomas", "Patrick Hunt"]:
+        fail("forbiddenGuestNames must preserve the two unconfirmed names", errors)
+
+    ctas = config.get("callsToAction", [])
+    if len(ctas) != 3:
+        fail("exactly three governed calls to action are required", errors)
+    for cta in ctas:
+        href = cta.get("href", "")
+        if not href.startswith("/?") or "#contact" not in href:
+            fail(f"CTA must use canonical relative intake route: {href}", errors)
+
+    if not html.strip().endswith("</section>"):
+        fail("payload must end with the root </section>", errors)
+
+    return write_result(errors, warnings)
+
+
+def write_result(errors: list[str], warnings: list[str]) -> int:
+    result = {
+        "html_file": str(HTML_PATH),
+        "config_file": str(CONFIG_PATH),
+        "errors": errors,
+        "warnings": warnings,
+        "ok": not errors,
+    }
+    OUT_PATH.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(json.dumps(result, indent=2))
+    return 0 if result["ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/proof-bluewave-signal.yml
+++ b/.github/workflows/proof-bluewave-signal.yml
@@ -16,6 +16,6 @@ jobs:
   proof:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Validate BlueWave Signal page
         run: python .github/scripts/proof_bluewave_signal.py

--- a/.github/workflows/proof-bluewave-signal.yml
+++ b/.github/workflows/proof-bluewave-signal.yml
@@ -1,0 +1,21 @@
+name: proof-bluewave-signal
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "web/bluewave/**"
+      - ".github/scripts/proof_bluewave_signal.py"
+      - ".github/workflows/proof-bluewave-signal.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  proof:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate BlueWave Signal page
+        run: python .github/scripts/proof_bluewave_signal.py

--- a/web/bluewave/README.md
+++ b/web/bluewave/README.md
@@ -1,0 +1,45 @@
+# BlueWave Signal public page
+
+This folder stages the public `/signal` Squarespace Code Block for BlueWave Action Group.
+
+## Current release
+
+- Version: `signal-squarespace-v2`
+- Stage: public pre-launch
+- Series: **Conversations for a Country Worth Building**
+- Primary publishing platform: Substack
+- Public route: `/signal`
+
+## Squarespace publication
+
+Use the complete contents of `signal.code.html` as the single Code Block payload for `/signal`.
+
+The new conversation-series feature is integrated inside `#bw-signal`, immediately after the hero and before the flagship-show placeholder. It uses the approved Squarespace CDN image at its native 16:9 ratio with `object-fit: contain`; do not crop it or restyle its embedded typography.
+
+Before publication:
+
+1. Back up the current live Code Block.
+2. Replace the whole block with `signal.code.html`; do not paste only fragments of its CSS or markup.
+3. Preview desktop, tablet, and mobile.
+4. Confirm the image loads without cropping or horizontal overflow.
+5. Confirm the three intake links arrive at `/#contact` with their query parameters intact.
+6. Confirm keyboard focus is visible and reduced-motion mode does not animate buttons.
+7. Publish only after the preview passes.
+
+Rollback is one operation: restore the backed-up Code Block.
+
+## Public boundary
+
+The page is intentionally guest-neutral. Do not name or imply a confirmed guest until written acceptance, recording details, and publication permissions are settled. Do not expose private systems, sensitive records, internal endpoints, analytics identifiers, or unpublished media.
+
+Substack, YouTube, podcast directories, and RSS should be described as live only when their public URLs resolve.
+
+## Validation
+
+Run from the repository root:
+
+```bash
+python .github/scripts/proof_bluewave_signal.py
+```
+
+The proof checks the approved image URL, 16:9 uncropped treatment, page placement, guest-neutral posture, accessible text, relative intake links, configuration agreement, and absence of forbidden public material.

--- a/web/bluewave/signal.code.html
+++ b/web/bluewave/signal.code.html
@@ -1,0 +1,177 @@
+<!--
+  BlueWave Signal / Squarespace one-shot
+  Version: signal-squarespace-v2
+  Public stage: pre-launch / guest-neutral
+-->
+<section id="bw-signal" data-version="signal-squarespace-v2" data-page="signal" data-canonical-path="/signal" aria-labelledby="bw-signal-title">
+  <style>
+    #bw-signal,#bw-signal *{box-sizing:border-box}
+    #bw-signal{--ink:#f7fbff;--muted:rgba(247,251,255,.74);--soft:rgba(247,251,255,.57);--line:rgba(121,184,255,.23);--blue:#3aa8ff;--blue2:#0057ff;--cyan:#69d5ff;--deep:#020713;font-family:Inter,Manrope,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:var(--ink);background:radial-gradient(circle at 16% 0%,rgba(58,168,255,.28),transparent 28rem),radial-gradient(circle at 88% 18%,rgba(0,87,255,.24),transparent 30rem),linear-gradient(180deg,#020713,#06101f 54%,#020713);overflow:hidden;text-rendering:optimizeLegibility;-webkit-font-smoothing:antialiased}
+    #bw-signal a{color:inherit}
+    #bw-signal h1,#bw-signal h2,#bw-signal h3,#bw-signal p,#bw-signal figure{margin:0}
+    #bw-signal img{max-width:100%}
+    #bw-signal .shell{width:min(1160px,calc(100% - 40px));margin:0 auto}
+    #bw-signal .hero{padding:clamp(72px,9vw,132px) 0 clamp(44px,7vw,88px);border-bottom:1px solid var(--line)}
+    #bw-signal .kicker,#bw-signal .label{color:var(--soft);font-size:.75rem;letter-spacing:.17em;text-transform:uppercase;font-weight:850}
+    #bw-signal .kicker{display:inline-flex;align-items:center;gap:10px}
+    #bw-signal .pulse{width:9px;height:9px;border-radius:999px;background:var(--blue);box-shadow:0 0 0 7px rgba(58,168,255,.12),0 0 34px rgba(58,168,255,.72)}
+    #bw-signal h1{max-width:960px;margin-top:18px;font-size:clamp(3.4rem,9vw,8.2rem);line-height:.86;letter-spacing:-.075em;font-weight:860;text-wrap:balance}
+    #bw-signal .dek{max-width:850px;margin-top:22px;color:var(--muted);font-size:clamp(1.12rem,2vw,1.42rem);line-height:1.55}
+    #bw-signal .rule{width:min(620px,100%);height:1px;margin-top:26px;background:linear-gradient(90deg,var(--blue),rgba(255,255,255,.7),transparent)}
+    #bw-signal .actions{display:flex;flex-wrap:wrap;gap:12px;margin-top:30px}
+    #bw-signal .btn,#bw-signal .btn2,#bw-signal .ghost{display:inline-flex;align-items:center;justify-content:center;min-height:46px;padding:12px 18px;border-radius:999px;font-size:.93rem;font-weight:820;text-align:center;text-decoration:none;border:1px solid var(--line);transition:transform 180ms ease,border-color 180ms ease,box-shadow 180ms ease}
+    #bw-signal .btn{background:linear-gradient(135deg,var(--blue),var(--blue2));color:#fff;border-color:rgba(255,255,255,.18);box-shadow:0 18px 54px rgba(0,87,255,.24)}
+    #bw-signal .btn2{background:rgba(255,255,255,.07);color:#fff}
+    #bw-signal .ghost{color:var(--soft);background:rgba(255,255,255,.035)}
+    #bw-signal .btn:focus-visible,#bw-signal .btn2:focus-visible,#bw-signal .ghost:focus-visible{outline:3px solid rgba(105,213,255,.92);outline-offset:4px}
+    #bw-signal .bw-body{padding:clamp(44px,7vw,86px) 0}
+    #bw-signal section.block{margin-top:clamp(44px,6vw,76px)}
+    #bw-signal section.block:first-child{margin-top:0}
+    #bw-signal .label{margin-bottom:12px}
+    #bw-signal h2{max-width:920px;font-size:clamp(2rem,4.6vw,4rem);line-height:.98;letter-spacing:-.055em;font-weight:860;text-wrap:balance}
+    #bw-signal .copy{max-width:820px;margin-top:14px;color:var(--muted);font-size:clamp(1rem,1.6vw,1.14rem);line-height:1.72}
+    #bw-signal .feature{overflow:hidden;margin-top:26px;border:1px solid var(--line);border-radius:30px;background:linear-gradient(145deg,rgba(255,255,255,.1),rgba(255,255,255,.035));box-shadow:0 28px 90px rgba(0,0,0,.34)}
+    #bw-signal .feature-media{position:relative;background:#020713}
+    #bw-signal .feature-media::after{content:"";position:absolute;inset:auto 0 0;height:26%;pointer-events:none;background:linear-gradient(180deg,transparent,rgba(2,7,19,.46))}
+    #bw-signal .feature-media img{display:block;width:100%;height:auto;aspect-ratio:16/9;object-fit:contain;background:#020713}
+    #bw-signal .feature-body{display:grid;grid-template-columns:minmax(0,1.25fr) minmax(280px,.75fr);gap:clamp(20px,4vw,42px);padding:clamp(22px,4vw,40px);align-items:start}
+    #bw-signal .promise{padding:20px;border:1px solid var(--line);border-radius:22px;background:rgba(255,255,255,.055);box-shadow:inset 3px 0 0 rgba(105,213,255,.72)}
+    #bw-signal .promise strong{display:block;font-size:clamp(1.15rem,2.4vw,1.5rem);line-height:1.18;letter-spacing:-.03em}
+    #bw-signal .promise p{margin-top:10px;color:var(--muted);font-size:.95rem;line-height:1.55}
+    #bw-signal .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:18px;padding:0;list-style:none}
+    #bw-signal .meta li,#bw-signal .status{display:inline-flex;align-items:center;min-height:34px;padding:7px 11px;border-radius:999px;background:rgba(58,168,255,.12);border:1px solid rgba(58,168,255,.22);color:#bdddff;font-size:.72rem;font-weight:850;letter-spacing:.08em;text-transform:uppercase}
+    #bw-signal .band{display:grid;grid-template-columns:minmax(0,1.14fr) minmax(280px,.86fr);gap:clamp(20px,4vw,42px);align-items:stretch;margin-top:26px}
+    #bw-signal .player{min-height:360px;padding:clamp(22px,4vw,38px);border:1px solid var(--line);border-radius:30px;background:linear-gradient(145deg,rgba(255,255,255,.1),rgba(255,255,255,.035));box-shadow:0 28px 90px rgba(0,0,0,.32)}
+    #bw-signal .screen{min-height:220px;border:1px solid rgba(255,255,255,.12);border-radius:22px;background:linear-gradient(135deg,#030812,#0a1f3d);display:grid;place-items:center;text-align:center;padding:28px;overflow:hidden}
+    #bw-signal .playmark{display:grid;gap:14px;justify-items:center}
+    #bw-signal .tri{width:70px;height:70px;border-radius:999px;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.18);display:grid;place-items:center}
+    #bw-signal .tri span{display:block;width:0;height:0;border-top:13px solid transparent;border-bottom:13px solid transparent;border-left:19px solid #fff;margin-left:5px}
+    #bw-signal .player h3{margin-top:20px;font-size:clamp(1.55rem,2.6vw,2.45rem);line-height:1.05;letter-spacing:-.045em}
+    #bw-signal .rail{display:grid;gap:14px}
+    #bw-signal .mini,#bw-signal .card{border:1px solid var(--line);border-radius:22px;background:rgba(255,255,255,.055);padding:20px}
+    #bw-signal .mini strong,#bw-signal .card strong{display:block;font-size:.84rem;letter-spacing:.12em;text-transform:uppercase;color:#fff}
+    #bw-signal .mini p,#bw-signal .card p{margin-top:9px;color:var(--muted);font-size:.96rem;line-height:1.55}
+    #bw-signal .grid3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:14px;margin-top:24px}
+    #bw-signal .grid4{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:14px;margin-top:24px}
+    #bw-signal .store{margin-top:24px;padding:clamp(24px,4vw,44px);border-radius:30px;border:1px solid var(--line);background:linear-gradient(135deg,rgba(58,168,255,.18),rgba(255,255,255,.06));display:grid;grid-template-columns:minmax(0,1fr) auto;gap:22px;align-items:center}
+    #bw-signal footer{display:flex;flex-wrap:wrap;justify-content:space-between;gap:14px;margin-top:clamp(44px,7vw,82px);padding-top:24px;border-top:1px solid var(--line);color:var(--soft);font-size:.9rem}
+    #bw-signal .sr-only{position:absolute!important;width:1px!important;height:1px!important;padding:0!important;margin:-1px!important;overflow:hidden!important;clip:rect(0,0,0,0)!important;white-space:nowrap!important;border:0!important}
+    @media(hover:hover){#bw-signal .btn:hover,#bw-signal .btn2:hover,#bw-signal .ghost:hover{transform:translateY(-2px);border-color:rgba(105,213,255,.7);box-shadow:0 18px 44px rgba(0,87,255,.24)}}
+    @media(max-width:920px){#bw-signal .feature-body,#bw-signal .band,#bw-signal .store{grid-template-columns:1fr}#bw-signal .grid3,#bw-signal .grid4{grid-template-columns:1fr 1fr}}
+    @media(max-width:640px){#bw-signal .shell{width:min(calc(100% - 28px),1160px)}#bw-signal h1{font-size:clamp(3rem,17vw,4.9rem)}#bw-signal .feature{border-radius:22px}#bw-signal .grid3,#bw-signal .grid4{grid-template-columns:1fr}#bw-signal .btn,#bw-signal .btn2,#bw-signal .ghost{width:100%}}
+    @media(prefers-reduced-motion:reduce){#bw-signal .btn,#bw-signal .btn2,#bw-signal .ghost{transition:none}#bw-signal .btn:hover,#bw-signal .btn2:hover,#bw-signal .ghost:hover{transform:none}}
+  </style>
+
+  <div class="hero">
+    <div class="shell">
+      <div class="kicker"><span class="pulse" aria-hidden="true"></span>BlueWave Action Group / Signal</div>
+      <h1 id="bw-signal-title">The signal starts here.</h1>
+      <div class="rule" aria-hidden="true"></div>
+      <p class="dek">BlueWave Signal is the public editorial home for serious writing, human stories, and conversations that make reality harder to evade—and renewal easier to imagine.</p>
+      <div class="actions">
+        <a class="btn" href="#conversations" data-bw-signal-event="open-conversations">Explore the conversation series</a>
+        <a class="btn2" href="#articles" data-bw-signal-event="read-articles">Read the writing</a>
+        <a class="ghost" href="/?interest=updates&amp;initiative=bluewave-signal&amp;source=signal-hero#contact" data-bw-signal-event="follow-signal">Follow the Signal</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="bw-body">
+    <div class="shell">
+      <section id="conversations" class="block" aria-labelledby="conversations-title">
+        <div class="label">Original conversation series · In development</div>
+        <h2 id="conversations-title">Conversations for a Country Worth Building</h2>
+        <p class="copy">Thoughtful conversations with Canadians whose experience, judgment, and public purpose can help make the country more intelligible—and more worthy of what comes next.</p>
+
+        <article class="feature" aria-label="Conversations for a Country Worth Building series">
+          <figure class="feature-media">
+            <img src="https://images.squarespace-cdn.com/content/67705dbf69e06a2e83e53c93/516a7db9-586f-416f-bcc2-fe834daf10eb/Conversations+for+a+Country+Worth+Building.png?content-type=image%2Fpng" alt="BlueWave Signal — Conversations for a Country Worth Building, connecting Ottawa and Vancouver." width="1648" height="928" loading="eager" decoding="async" fetchpriority="high">
+            <figcaption class="sr-only">The canonical BlueWave Signal visual for Conversations for a Country Worth Building.</figcaption>
+          </figure>
+          <div class="feature-body">
+            <div>
+              <h3>Public value first. No theatre.</h3>
+              <p class="copy">One guest. One serious question. Thirty minutes. The series will bring lived experience, evidence, and moral judgment into the same room without turning conversation into performance.</p>
+              <ul class="meta" aria-label="Conversation series format">
+                <li>Canada</li>
+                <li>Video + editorial</li>
+                <li>Guest-neutral pre-launch</li>
+              </ul>
+              <div class="actions">
+                <a class="btn" href="/?interest=updates&amp;initiative=bluewave-signal&amp;source=signal-conversations#contact" data-bw-signal-event="conversation-updates">Follow the launch</a>
+                <a class="btn2" href="/?interest=general&amp;initiative=bluewave-signal&amp;source=propose-guest#contact" data-bw-signal-event="propose-guest">Propose a guest or question</a>
+              </div>
+            </div>
+            <aside class="promise" aria-label="Editorial and consent boundary">
+              <strong>Guest announcements come after consent—not before.</strong>
+              <p>No guest is presented as confirmed until written acceptance, recording details, and publication permissions are settled. The work is serious enough to wait.</p>
+            </aside>
+          </div>
+        </article>
+      </section>
+
+      <section id="flagship-show" class="block" aria-labelledby="flagship-title">
+        <div class="label">Substack video podcast</div>
+        <h2 id="flagship-title">The show lives with the writing.</h2>
+        <p class="copy">Substack remains the primary publishing home for approved episodes, essays, show notes, transcripts, and sources. The `/signal` page is the curated public doorway—not a second content-management system.</p>
+        <div class="band">
+          <article class="player">
+            <div class="screen"><div class="playmark"><div class="tri" aria-hidden="true"><span></span></div><strong>First approved conversation pending</strong></div></div>
+            <h3>BlueWave Signal</h3>
+            <p class="copy">This frame becomes the latest-episode module only after the public post, captions, transcript, guest permissions, and links pass review.</p>
+            <div class="actions"><a class="btn" href="#launch-checklist">View launch standard</a><a class="btn2" href="#podcast">Distribution plan</a></div>
+          </article>
+          <aside class="rail">
+            <div class="mini"><strong>Primary home</strong><p>Substack is the primary home for video conversations and the companion writing stream.</p></div>
+            <div class="mini"><strong>Status</strong><p>Series identity and public page module are ready. The first public episode remains in development.</p><span class="status">In development</span></div>
+            <div class="mini"><strong>Boundary</strong><p>Public media only. No private systems, sensitive records, or unapproved guest material.</p></div>
+          </aside>
+        </div>
+      </section>
+
+      <section id="podcast" class="block" aria-labelledby="podcast-title">
+        <div class="label">Podcast distribution</div>
+        <h2 id="podcast-title">Substack first; syndication second.</h2>
+        <p class="copy">Add audio feeds and directories only after the official Substack video-podcast path is live and each public listing resolves.</p>
+        <div class="grid4">
+          <article class="card"><strong>Substack</strong><p>Primary video conversation and writing home. Public URL added when approved.</p><span class="status">In development</span></article>
+          <article class="card"><strong>Apple Podcasts</strong><p>Audio distribution after the primary Substack path is proven.</p><span class="status">Planned</span></article>
+          <article class="card"><strong>Spotify</strong><p>Audio distribution after the primary Substack path is proven.</p><span class="status">Planned</span></article>
+          <article class="card"><strong>RSS</strong><p>Feed remains unpublished until the first episode clears quality control.</p><span class="status">Planned</span></article>
+        </div>
+      </section>
+
+      <section id="articles" class="block" aria-labelledby="articles-title">
+        <div class="label">Writing beside the conversation</div>
+        <h2 id="articles-title">The essays carry the argument; the people carry the truth.</h2>
+        <p class="copy">BlueWave Signal combines original essays, companion notes, transcripts, corrections, and selected public sources. Human testimony is handled with consent, context, and evidence discipline.</p>
+        <div class="grid3">
+          <article class="card"><strong>Essays</strong><p>Original analysis that clarifies the public question before and after each conversation.</p><span class="status">Live stream</span></article>
+          <article class="card"><strong>Show notes</strong><p>Chapters, verified links, selected sources, disclosures, and transcript access.</p><span class="status">With episodes</span></article>
+          <article class="card"><strong>Corrections</strong><p>Material errors are corrected visibly. Uncertainty is marked rather than hidden.</p><span class="status">Required</span></article>
+        </div>
+      </section>
+
+      <section id="store" class="block" aria-labelledby="store-title">
+        <div class="store">
+          <div><div class="label">Support</div><h2 id="store-title">Help serious public work travel farther.</h2><p class="copy">Partnership, sponsorship, and public-support pathways are handled through BlueWave’s canonical intake until dedicated commerce and sponsorship rails are verified.</p></div>
+          <a class="btn" href="/?interest=sponsorship&amp;initiative=bluewave-signal&amp;source=signal-support#contact" data-bw-signal-event="support-signal">Support the Signal</a>
+        </div>
+      </section>
+
+      <section id="launch-checklist" class="block" aria-labelledby="checklist-title">
+        <div class="label">Publication standard</div>
+        <h2 id="checklist-title">Consent, evidence, and technical quality before the clock.</h2>
+        <div class="grid3">
+          <article class="card"><strong>1. Guest and rights</strong><p>Written acceptance, boundaries, biography, recording rights, and publication permissions are documented.</p></article>
+          <article class="card"><strong>2. Editorial proof</strong><p>The question, source ledger, contested claims, captions, transcript, and public/private boundary pass review.</p></article>
+          <article class="card"><strong>3. Technical proof</strong><p>Audio, image, backup, accessibility, mobile layout, metadata, and every public link are verified.</p></article>
+        </div>
+      </section>
+
+      <footer><div><strong>BlueWave Action Group</strong></div><div>Public signal, not private command.</div><div>Conversations / Essays / Human Stories</div></footer>
+    </div>
+  </div>
+
+  <script>(function(){function emit(name,detail){try{document.dispatchEvent(new CustomEvent(name,{detail:detail||{}}));}catch(_){}}emit("bluewave:signal:ready",{page:"/signal",version:"signal-squarespace-v2",series:"conversations_for_a_country_worth_building",primary_platform:"Substack",episode_status:"in_development"});document.querySelectorAll("#bw-signal [data-bw-signal-event]").forEach(function(el){el.addEventListener("click",function(){emit("bluewave:signal:click",{event:el.getAttribute("data-bw-signal-event"),href:el.getAttribute("href"),label:(el.textContent||"").trim()});});});})();</script>
+</section>

--- a/web/bluewave/signal.config.json
+++ b/web/bluewave/signal.config.json
@@ -1,0 +1,64 @@
+{
+  "page": "/signal",
+  "brand": "BlueWave Action Group",
+  "version": "signal-squarespace-v2",
+  "mode": "public_prelaunch",
+  "primaryPlatform": "Substack",
+  "contentModel": "conversations_plus_writing",
+  "series": {
+    "name": "BlueWave Signal",
+    "tagline": "Conversations for a Country Worth Building",
+    "status": "in_development",
+    "format": "one_guest_one_serious_question_thirty_minutes_no_theatre",
+    "imageUrl": "https://images.squarespace-cdn.com/content/67705dbf69e06a2e83e53c93/516a7db9-586f-416f-bcc2-fe834daf10eb/Conversations+for+a+Country+Worth+Building.png?content-type=image%2Fpng",
+    "imageAspectRatio": "16:9",
+    "imageCrop": "none",
+    "alt": "BlueWave Signal — Conversations for a Country Worth Building, connecting Ottawa and Vancouver."
+  },
+  "safety": {
+    "publicOnly": true,
+    "privateCommandAllowed": false,
+    "guestNeutralUntilConfirmed": true,
+    "requiresWrittenAcceptance": true,
+    "requiresPublicationPermission": true,
+    "forbiddenGuestNames": [
+      "Patrick Hunt",
+      "Maldwyn Thomas"
+    ],
+    "notes": [
+      "Do not announce a guest until written acceptance, recording details, and publication permissions are confirmed.",
+      "Do not expose private systems, internal endpoints, analytics identifiers, sensitive records, or unpublished episode assets.",
+      "Promote a platform or directory from planned to live only after its public URL resolves."
+    ]
+  },
+  "placement": {
+    "insideRoot": "#bw-signal",
+    "after": "hero",
+    "before": "flagship-show"
+  },
+  "callsToAction": [
+    {
+      "label": "Follow the launch",
+      "href": "/?interest=updates&initiative=bluewave-signal&source=signal-conversations#contact",
+      "status": "live_relative_route"
+    },
+    {
+      "label": "Propose a guest or question",
+      "href": "/?interest=general&initiative=bluewave-signal&source=propose-guest#contact",
+      "status": "live_relative_route"
+    },
+    {
+      "label": "Support the Signal",
+      "href": "/?interest=sponsorship&initiative=bluewave-signal&source=signal-support#contact",
+      "status": "live_relative_route"
+    }
+  ],
+  "publishing": {
+    "episodeStatus": "in_development",
+    "substackUrl": "",
+    "youtubeUrl": "",
+    "applePodcastsUrl": "",
+    "spotifyUrl": "",
+    "rssUrl": ""
+  }
+}


### PR DESCRIPTION
## Summary

Updates the canonical BlueWave `/signal` Squarespace payload from the original scaffold to a governed pre-launch page for **Conversations for a Country Worth Building**.

## What changed

- Integrates the approved Squarespace CDN graphic inside `#bw-signal`
- Places the series after the hero and before the flagship-show module
- Preserves the graphic at native 16:9 with no crop
- Adds guest-neutral pre-launch copy and consent boundary
- Routes follow, guest/question, and sponsorship actions through canonical `/#contact` intake parameters
- Reframes the page around conversations, writing, and publication discipline
- Adds a configuration manifest, publication/rollback runbook, and automated proof

## Public-safety posture

- No unconfirmed guest names appear publicly
- No platform or podcast directory is claimed live without a resolving public URL
- No private systems, sensitive records, internal endpoints, analytics identifiers, or unpublished media are exposed

## Manual publication gate

Before Squarespace publication, back up the current Code Block and preview desktop, tablet, and mobile. Confirm the image is uncropped, there is no horizontal overflow, keyboard focus is visible, and all intake links reach `/#contact` with query parameters intact.
