### PR TITLE
Harden GCloud WIF provider validation and legacy normalization

### DIFF
--- a/.github/workflows/cicd-deploy.yml
+++ b/.github/workflows/cicd-deploy.yml
@@ -24,6 +24,7 @@ jobs:
       # root and explicitly enables this repository through variables.
       DEPLOY_ENABLED: ${{ vars.ENABLE_OIDC_DEPLOY || 'false' }}
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID || secrets.GCP_PROJECT_ID || 'f5-prod-command-core' }}
+      GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER || '732190342674' }}
       WIF_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER || secrets.GCP_WORKLOAD_IDENTITY_PROVIDER || secrets.GCP_WIF_PROVIDER || '' }}
       WIF_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL || secrets.GCP_SERVICE_ACCOUNT_EMAIL || secrets.GCP_WIF_SA_EMAIL || '' }}
     steps:
@@ -37,6 +38,8 @@ jobs:
         run: |
           set -euo pipefail
           missing=()
+          canonical_provider=""
+
           if [ "${DEPLOY_ENABLED}" != "true" ]; then
             missing+=("ENABLE_OIDC_DEPLOY is not true")
           fi
@@ -49,6 +52,27 @@ jobs:
           if [ -z "${GCP_PROJECT_ID}" ]; then
             missing+=("GCP_PROJECT_ID")
           fi
+          if ! [[ "${GCP_PROJECT_NUMBER}" =~ ^[0-9]+$ ]]; then
+            missing+=("GCP_PROJECT_NUMBER must be numeric")
+          fi
+
+          # google-github-actions/auth requires the full provider resource name:
+          # projects/NUMBER/locations/global/workloadIdentityPools/POOL/providers/PROVIDER
+          # A legacy POOL/PROVIDER shorthand is normalized only when the numeric
+          # project number is known. Any other shape fails closed before STS.
+          if [ -n "${WIF_PROVIDER}" ] && [[ "${GCP_PROJECT_NUMBER}" =~ ^[0-9]+$ ]]; then
+            if [[ "${WIF_PROVIDER}" =~ ^projects/([0-9]+)/locations/global/workloadIdentityPools/([^/]+)/providers/([^/]+)$ ]]; then
+              if [ "${BASH_REMATCH[1]}" != "${GCP_PROJECT_NUMBER}" ]; then
+                missing+=("WIF provider project number does not match GCP_PROJECT_NUMBER")
+              else
+                canonical_provider="${WIF_PROVIDER}"
+              fi
+            elif [[ "${WIF_PROVIDER}" =~ ^([^/]+)/([^/]+)$ ]]; then
+              canonical_provider="projects/${GCP_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${BASH_REMATCH[1]}/providers/${BASH_REMATCH[2]}"
+            else
+              missing+=("WIF provider must be full resource name or POOL/PROVIDER shorthand")
+            fi
+          fi
 
           if [ "${#missing[@]}" -gt 0 ]; then
             echo "ready=false" >> "$GITHUB_OUTPUT"
@@ -57,12 +81,14 @@ jobs:
             echo "ready=true" >> "$GITHUB_OUTPUT"
             echo "missing=" >> "$GITHUB_OUTPUT"
           fi
+          printf 'provider=%s\n' "${canonical_provider}" >> "$GITHUB_OUTPUT"
 
           echo "project=${GCP_PROJECT_ID}"
-          if [ -n "${WIF_PROVIDER}" ]; then
-            echo "provider=${WIF_PROVIDER##*/}"
+          echo "project_number=${GCP_PROJECT_NUMBER}"
+          if [ -n "${canonical_provider}" ]; then
+            echo "provider=${canonical_provider##*/}"
           else
-            echo "provider=absent"
+            echo "provider=absent-or-invalid"
           fi
           if [ -n "${WIF_SERVICE_ACCOUNT}" ]; then
             echo "service_account_domain=${WIF_SERVICE_ACCOUNT#*@}"
@@ -87,6 +113,7 @@ jobs:
               "generatedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
               "expectedSha": os.environ["GITHUB_SHA"],
               "projectId": os.environ.get("GCP_PROJECT_ID", ""),
+              "projectNumber": os.environ.get("GCP_PROJECT_NUMBER", ""),
               "state": "WITHHELD",
               "pass": False,
               "reason": os.environ.get("MISSING_CONTROLS", "deployment prerequisites absent"),
@@ -102,7 +129,7 @@ jobs:
         if: steps.preflight.outputs.ready == 'true'
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
-          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          workload_identity_provider: ${{ steps.preflight.outputs.provider }}
           service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
 
       - name: Set up gcloud
@@ -244,6 +271,7 @@ jobs:
               "generatedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
               "expectedSha": os.environ["GITHUB_SHA"],
               "projectId": os.environ.get("GCP_PROJECT_ID", ""),
+              "projectNumber": os.environ.get("GCP_PROJECT_NUMBER", ""),
               "state": "FAILED_BEFORE_PUBLIC_VERIFICATION",
               "pass": False,
               "certificationRule": "Authentication or build failure is never public-demo GREEN.",

--- a/deploy_demo.sh
+++ b/deploy_demo.sh
@@ -1,64 +1,73 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PROJECT_ID="${PROJECT_ID:-732190342674}"
+# Canonical public-demo deployment is GitHub OIDC via .github/workflows/cicd-deploy.yml.
+# This local script is retained only as an explicitly gated recovery path.
+PROJECT_ID="${PROJECT_ID:-f5-prod-command-core}"
+PROJECT_NUMBER="${PROJECT_NUMBER:-732190342674}"
 REGION="${REGION:-us-central1}"
-SERVICE_NAME="${SERVICE_NAME:-dominion-demo}"
+SERVICE_NAME="${SERVICE_NAME:-demo}"
 AR_REPO="${AR_REPO:-dominion-demo-repo}"
 DOCKERFILE="${DOCKERFILE:-Dockerfile.production}"
 BUILD_CONTEXT="${BUILD_CONTEXT:-.}"
 TAG="${TAG:-latest}"
-DEMO_HOST="${DEMO_HOST:-https://www.fractal5solutions.com/demo}"
+PUBLIC_DEMO_BASE_URL="${PUBLIC_DEMO_BASE_URL:-https://demo-reduwyf2ra-uc.a.run.app}"
+ALLOW_MUTATING_LOCAL_DEPLOY="${ALLOW_MUTATING_LOCAL_DEPLOY:-false}"
 
-echo "== Fractal5 Demo Deploy =="
-echo "Project:  ${PROJECT_ID}"
-echo "Region:   ${REGION}"
-echo "Service:   ${SERVICE_NAME}"
-echo "Image:    ${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/${SERVICE_NAME}:${TAG}"
+echo "== Fractal5 Demo Deploy Recovery Path =="
+echo "Project ID:      ${PROJECT_ID}"
+echo "Project number:  ${PROJECT_NUMBER}"
+echo "Region:          ${REGION}"
+echo "Service:         ${SERVICE_NAME}"
+echo "Image:           ${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/${SERVICE_NAME}:${TAG}"
+echo
 
-if ! gcloud auth list --filter=status:ACTIVE --format='value(account)' | grep -q '@'; then
-  echo "ERROR: no active gcloud identity found. Run: gcloud auth login"
+echo "Canonical deployment path: GitHub Actions OIDC (.github/workflows/cicd-deploy.yml)"
+echo "This local script is fail-closed by default."
+
+if [ "${ALLOW_MUTATING_LOCAL_DEPLOY}" != "true" ]; then
+  echo
+  echo "WITHHELD: local mutation is disabled."
+  echo "Set ALLOW_MUTATING_LOCAL_DEPLOY=true only for an explicitly authorized recovery deployment."
+  echo "No APIs, IAM bindings, Artifact Registry repositories, builds, or Cloud Run services were changed."
+  exit 3
+fi
+
+if ! gcloud auth list --filter=status:ACTIVE --format='value(account)' | grep -q .; then
+  echo "ERROR: no active gcloud identity found."
+  exit 1
+fi
+
+ACTUAL_PROJECT_NUMBER="$(gcloud projects describe "${PROJECT_ID}" --format='value(projectNumber)')"
+if [ "${ACTUAL_PROJECT_NUMBER}" != "${PROJECT_NUMBER}" ]; then
+  echo "ERROR: project identity mismatch. Expected ${PROJECT_NUMBER}; got ${ACTUAL_PROJECT_NUMBER}."
   exit 1
 fi
 
 gcloud config set project "${PROJECT_ID}" >/dev/null
 
-PROJECT_NUMBER="$(gcloud projects describe "${PROJECT_ID}" --format='value(projectNumber)')"
-BUILD_SA="${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com"
-
-for api in run.googleapis.com cloudbuild.googleapis.com artifactregistry.googleapis.com secretmanager.googleapis.com compute.googleapis.com dns.googleapis.com iap.googleapis.com; do
-  gcloud services enable "${api}" --quiet >/dev/null
-done
-
+# Do not create or broaden IAM bindings here. The recovery path requires the
+# necessary least-privilege permissions to exist already. Provider/IAM repair
+# belongs to an authenticated Google Cloud owner session and must be receipt-backed.
 if ! gcloud artifacts repositories describe "${AR_REPO}" --project="${PROJECT_ID}" --location="${REGION}" >/dev/null 2>&1; then
-  gcloud artifacts repositories create "${AR_REPO}" \
-    --project="${PROJECT_ID}" \
-    --location="${REGION}" \
-    --repository-format=docker \
-    --description="Docker repo for Fractal5 demo"
+  echo "ERROR: Artifact Registry repository ${AR_REPO} is absent. Refusing to create it from the recovery script."
+  exit 1
 fi
-
-gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-  --member="serviceAccount:${BUILD_SA}" \
-  --role="roles/artifactregistry.writer" >/dev/null
-gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-  --member="serviceAccount:${BUILD_SA}" \
-  --role="roles/run.admin" >/dev/null
 
 gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
 
 gcloud builds submit "${BUILD_CONTEXT}" \
   --project="${PROJECT_ID}" \
   --config=cloudbuild.yaml \
-  --substitutions="_SERVICE_NAME=${SERVICE_NAME},_REGION=${REGION},_AR_REPO=${AR_REPO},_DOCKERFILE=${DOCKERFILE},_BUILD_CONTEXT=${BUILD_CONTEXT},_TAG=${TAG}"
+  --substitutions="_SERVICE_NAME=${SERVICE_NAME},_REGION=${REGION},_AR_REPO=${AR_REPO},_DOCKERFILE=${DOCKERFILE},_BUILD_CONTEXT=${BUILD_CONTEXT},_TAG=${TAG},_APP_VERSION=${TAG}"
 
 SERVICE_URL="$(gcloud run services describe "${SERVICE_NAME}" --project="${PROJECT_ID}" --region="${REGION}" --format='value(status.url)')"
 
 echo
-echo "Deployment complete."
+echo "Recovery deployment submitted."
 echo "Service URL: ${SERVICE_URL}"
-echo "Demo URL:    ${DEMO_HOST}"
-echo
-echo "Smoke checks:"
-echo "  curl -I ${DEMO_HOST}"
-echo "  curl -s ${SERVICE_URL}/healthz"
+echo "Required verification:"
+echo "  ${PUBLIC_DEMO_BASE_URL}/demo"
+echo "  ${PUBLIC_DEMO_BASE_URL}/health"
+echo "  ${PUBLIC_DEMO_BASE_URL}/status"
+echo "Do not claim runtime GREEN until the exact-release receipt passes."

--- a/ops/DEPLOY_RUNBOOK.md
+++ b/ops/DEPLOY_RUNBOOK.md
@@ -1,96 +1,120 @@
 # Fractal5 Demo Deploy Runbook
 
-Primary target:
-- Project: `732190342674`
-- Demo URL: `https://www.fractal5solutions.com/demo`
-- Service: `dominion-demo`
+## Canonical target
+
+- Project ID: `f5-prod-command-core`
+- Project number: `732190342674`
+- Cloud Run service: `demo`
 - Region: `us-central1`
+- Public runtime base: `https://demo-reduwyf2ra-uc.a.run.app`
+- Required runtime routes: `/demo`, `/health`, `/status`
+- Canonical deployment workflow: `.github/workflows/cicd-deploy.yml`
 
-## Deploy sequence
+The GitHub OIDC workflow is the canonical deployment path. Local `gcloud auth login` and ad-hoc IAM mutation are not the normal deployment model.
 
-1. Authenticate:
+## Identity contract
 
-```bash
-gcloud auth login --brief
-gcloud config set project 732190342674
-gh auth status
+GitHub Actions authentication uses short-lived Google Workload Identity Federation credentials. The provider must be the full resource name:
+
+```text
+projects/732190342674/locations/global/workloadIdentityPools/POOL/providers/PROVIDER
 ```
 
-2. Confirm the secure build path:
+The configured deployment service account is expected to be a dedicated least-privilege identity for this repository. Static service-account JSON keys are not an approved fallback.
+
+The current governed provider identifiers are tracked in issue #189 and the repository deployment workflow. A shorthand `POOL/PROVIDER` value may be normalized by the workflow, but it must resolve to the numeric project number above.
+
+## Repository-side preflight
+
+The deployment workflow must fail closed unless all of the following are true:
+
+1. `ENABLE_OIDC_DEPLOY=true`.
+2. `GCP_PROJECT_ID` resolves to `f5-prod-command-core` unless an intentionally approved successor is documented.
+3. `GCP_PROJECT_NUMBER` is numeric and matches the provider resource.
+4. The WIF provider resolves to a full provider resource name.
+5. The deployment service-account identity is configured.
+
+Malformed, missing, or mismatched identity inputs must produce a WITHHELD receipt rather than attempting deployment.
+
+## Google Cloud owner verification
+
+An authenticated Google Cloud owner/operator session is required to verify or restore the provider-side trust root. Read-only verification should establish:
 
 ```bash
-./deploy_demo.sh
+gcloud auth list
+gcloud config list
+gcloud projects describe f5-prod-command-core --format='value(projectNumber)'
+gcloud iam workload-identity-pools describe fractal5-github-pool \
+  --project=f5-prod-command-core \
+  --location=global
+gcloud iam workload-identity-pools providers describe github-provider \
+  --project=f5-prod-command-core \
+  --location=global \
+  --workload-identity-pool=fractal5-github-pool
+gcloud iam service-accounts describe \
+  dominion-demo-oidc-sa@f5-prod-command-core.iam.gserviceaccount.com \
+  --project=f5-prod-command-core
 ```
 
-3. Verify the Cloud Run revision:
+Do not interpret repository configuration as proof that the provider exists or is ACTIVE.
+
+## Provider restoration boundary
+
+If the provider is absent, disabled, or deleted, restoration is a Google Cloud control-plane action. It must preserve:
+
+- issuer `https://token.actions.githubusercontent.com`;
+- attribute mappings required by the GitHub trust policy;
+- a condition restricted to the approved Fractal5 organization/repository/ref scope;
+- `roles/iam.workloadIdentityUser` only for the intended principal set on the dedicated deployment service account;
+- no long-lived service-account key fallback.
+
+Provider/IAM restoration must be followed by a fresh GitHub OIDC authentication receipt before runtime deployment is considered available.
+
+## Runtime certificate gate
+
+After authenticated deployment of the exact certified source commit, require all of the following before GREEN:
+
+```text
+GET /demo    -> HTTP 200
+GET /health  -> HTTP 200 JSON
+GET /status  -> HTTP 200 JSON
+```
+
+`/health` and `/status` must include `Cache-Control: no-store`. The runtime receipt must bind the expected source SHA to the deployed release SHA and named Cloud Run revision. Claim-safety checks must pass.
+
+A successful build alone is not runtime GREEN.
+
+## Local recovery script
+
+`deploy_demo.sh` is retained as an explicitly gated recovery path only. It is fail-closed unless:
 
 ```bash
-gcloud run services describe dominion-demo --project=732190342674 --region=us-central1
-gcloud run revisions list --project=732190342674 --region=us-central1 --service=dominion-demo
+ALLOW_MUTATING_LOCAL_DEPLOY=true ./deploy_demo.sh
 ```
 
-4. Verify the public path:
-
-```bash
-curl -I https://www.fractal5solutions.com/demo
-curl -s https://www.fractal5solutions.com/demo/healthz
-```
-
-5. Verify IAP policy:
-
-```bash
-gcloud iap web get-iam-policy \
-  --project=732190342674 \
-  --resource-type=backend-services \
-  --service=dominion-demo-backend
-```
-
-## Expected state
-
-- Cloud Run ingress is `internal-and-cloud-load-balancing`
-- Unauthenticated requests to `/demo` are blocked by IAP
-- The load balancer resolves to the DNS A record
-- The demo page renders without console errors
-- The store and health endpoints remain available
-
-## Required IAM helpers
-
-The Cloud Build service account also needs deploy privileges:
-
-```bash
-PROJECT_NUMBER="$(gcloud projects describe 732190342674 --format='value(projectNumber)')"
-BUILD_SA="${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com"
-gcloud projects add-iam-policy-binding 732190342674 --member="serviceAccount:${BUILD_SA}" --role="roles/artifactregistry.writer"
-gcloud projects add-iam-policy-binding 732190342674 --member="serviceAccount:${BUILD_SA}" --role="roles/run.admin"
-```
-
-If the Cloud Run service later reads Secret Manager values, grant the runtime service account `roles/secretmanager.secretAccessor` as well.
+That flag is not authorization by itself. The recovery path must only be used for a specifically approved deployment. It no longer creates APIs, Artifact Registry repositories, or IAM role bindings automatically.
 
 ## Failure triage
 
-If the build fails:
+For authenticated read-only diagnosis:
 
 ```bash
-gcloud builds list --project=732190342674 --limit=10
-gcloud builds log BUILD_ID --project=732190342674
+gcloud builds list --project=f5-prod-command-core --limit=10
+gcloud run services describe demo --project=f5-prod-command-core --region=us-central1
+gcloud run revisions list --project=f5-prod-command-core --region=us-central1 --service=demo
 ```
 
-If Cloud Run fails:
+If the GitHub auth action reports `invalid_target`, first verify that the provider input is the full numeric-project resource name. If the canonical resource name is already correct, treat the failure as evidence that the provider-side trust root is absent, disabled, deleted, or otherwise not usable and keep deployment WITHHELD.
 
-```bash
-gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="dominion-demo"' --project=732190342674 --limit=100
-```
+## Completion definition
 
-If IAP fails:
+GCloud public-demo authentication/runtime is complete only when:
 
-```bash
-gcloud iap web get-iam-policy --project=732190342674 --resource-type=backend-services --service=dominion-demo-backend
-```
+1. the WIF provider exists and is ACTIVE;
+2. the trust condition and service-account binding are least-privilege and repository/ref scoped;
+3. GitHub obtains a short-lived federated credential successfully;
+4. the exact certified source commit is deployed to service `demo` in `us-central1`;
+5. `/demo`, `/health`, and `/status` pass the receipt contract;
+6. the runtime certificate is current and bound to the deployed SHA/revision.
 
-If DNS or TLS fails:
-
-```bash
-gcloud compute forwarding-rules list --global --project=732190342674
-gcloud compute ssl-certificates list --project=732190342674
-gcloud dns record-sets list --zone=fractal5-zone --project=732190342674
-```
+Until then, GCloud authentication/runtime remains WITHHELD by design.


### PR DESCRIPTION
## Objective
Repair the repository-controlled portion of the current Google Cloud OIDC `invalid_target` lane and eliminate stale local deployment drift without weakening fail-closed controls.

## Changes
- adds the numeric Google Cloud project-number identifier (`732190342674`) as an explicit deploy input, overridable by repository variable;
- requires the WIF provider to resolve to Google's documented full resource shape `projects/NUMBER/locations/global/workloadIdentityPools/POOL/providers/PROVIDER`;
- safely normalizes the known legacy `POOL/PROVIDER` shorthand using the numeric project number;
- rejects project-number mismatches and malformed provider values before calling STS;
- passes only the canonical provider output into `google-github-actions/auth`;
- preserves WITHHELD receipts and adds project-number context for diagnosis;
- aligns the deployment runbook to project ID `f5-prod-command-core`, project number `732190342674`, service `demo`, region `us-central1`, and `/demo` `/health` `/status` certificate routes;
- converts the stale local deploy script into an explicitly gated recovery path and removes automatic API enablement, Artifact Registry creation, and IAM role broadening from that script.

## Safety
No Google IAM resource is created, deleted or modified by this PR. No secret is exposed. No deployment is enabled. The local recovery script now fails closed unless explicitly authorized. If the Google provider is genuinely absent/disabled/deleted, authentication remains RED and the provider-side owner gate stays explicit.

## Evidence
Google's official `google-github-actions/auth` documentation requires the full provider resource name and numeric project number. The prior repo also contained configuration drift: the legacy runbook/script used numeric project value `732190342674` as the project identifier and service `dominion-demo`, while the governed workflow and Cloud Build contract use `f5-prod-command-core` / `demo`.

Related: #189, #180.